### PR TITLE
:feat: per-client API tracking and rate limiting

### DIFF
--- a/prisma/migrations/20260223000000_add_api_key_table/migration.sql
+++ b/prisma/migrations/20260223000000_add_api_key_table/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "ApiKey" (
+    "id" SERIAL NOT NULL,
+    "keyHash" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "rateLimit" INTEGER NOT NULL DEFAULT 1000,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3),
+
+    CONSTRAINT "ApiKey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApiKey_keyHash_key" ON "ApiKey"("keyHash");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApiKey_name_key" ON "ApiKey"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,6 +72,16 @@ model JsonWebKeySets {
   provenanceVerified Boolean?
 }
 
+model ApiKey {
+  id         Int       @id @default(autoincrement())
+  keyHash    String    @unique // SHA-256 hash of the raw key (never store raw)
+  name       String    @unique // human label e.g. "kapwing"
+  rateLimit  Int       @default(1000) // requests per second
+  isActive   Boolean   @default(true)
+  createdAt  DateTime  @default(now())
+  lastUsedAt DateTime?
+}
+
 enum KeyType {
   RSA
   Ed25519

--- a/scripts/generate-api-key.ts
+++ b/scripts/generate-api-key.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env ts-node
+/**
+ * Generate and register a new API key for a client.
+ *
+ * Usage:
+ *   npx ts-node scripts/generate-api-key.ts --name <client-name> [--rate-limit <req/sec>]
+ *
+ * Example:
+ *   npx ts-node scripts/generate-api-key.ts --name kapwing --rate-limit 5000
+ *
+ * The script prints the raw API key to stdout. This is the only time it is
+ * visible — share it with the client securely. The database only stores a
+ * SHA-256 hash.
+ */
+
+import 'dotenv/config';
+
+import { PrismaPg } from '@prisma/adapter-pg';
+import crypto from 'crypto';
+import { Pool } from 'pg';
+
+import { PrismaClient } from '../src/generated/prisma/client';
+
+// ─── Argument parsing ─────────────────────────────────────────────────────────
+
+function parseArgs(): { name: string; rateLimit: number } {
+  const args = process.argv.slice(2);
+  let name: string | undefined;
+  let rateLimit = 1000;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--name' && args[i + 1]) {
+      name = args[++i];
+    } else if (args[i] === '--rate-limit' && args[i + 1]) {
+      rateLimit = parseInt(args[++i], 10);
+      if (isNaN(rateLimit) || rateLimit <= 0) {
+        console.error('--rate-limit must be a positive integer');
+        process.exit(1);
+      }
+    }
+  }
+
+  if (!name) {
+    console.error(
+      'Usage: ts-node scripts/generate-api-key.ts --name <name> [--rate-limit <req/sec>]'
+    );
+    process.exit(1);
+  }
+
+  return { name, rateLimit };
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const { name, rateLimit } = parseArgs();
+
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    // Generate a cryptographically random 32-byte key, base64url-encoded
+    const rawKey = crypto.randomBytes(32).toString('base64url');
+    const keyHash = crypto.createHash('sha256').update(rawKey).digest('hex');
+
+    await prisma.apiKey.create({
+      data: {
+        keyHash,
+        name,
+        rateLimit,
+        isActive: true,
+      },
+    });
+
+    console.log(`\nAPI key created for client: ${name}`);
+    console.log(`Rate limit: ${rateLimit} req/sec`);
+    console.log(
+      `\nRaw API key (share securely — this is the only time it will be shown):`
+    );
+    console.log(`\n  ${rawKey}\n`);
+    console.log(`Clients should send it as: x-api-key: ${rawKey}`);
+  } catch (error: unknown) {
+    if (error instanceof Error && error.message.includes('Unique constraint')) {
+      console.error(`Error: a key with name "${name}" already exists.`);
+    } else {
+      console.error('Failed to create API key:', error);
+    }
+    process.exit(1);
+  } finally {
+    await prisma.$disconnect();
+    await pool.end();
+  }
+}
+
+main();

--- a/src/app/api/dsp/route.ts
+++ b/src/app/api/dsp/route.ts
@@ -1,6 +1,5 @@
 import { headers } from 'next/headers';
 import { type NextRequest, NextResponse } from 'next/server';
-import { RateLimiterMemory } from 'rate-limiter-flexible';
 
 import {
   badRequest,
@@ -8,12 +7,12 @@ import {
   serverError,
   validationError,
 } from '@/lib/api-response';
-import { logger } from '@/lib/logger';
 import {
-  addDomainSelectorPair,
-  type AddResult,
-  checkRateLimiter,
-} from '@/lib/utils_server';
+  checkClientRateLimit,
+  resolveClientIdentity,
+} from '@/lib/client-identity';
+import { logger } from '@/lib/logger';
+import { addDomainSelectorPair, type AddResult } from '@/lib/utils_server';
 import { type DspBody, dspBodySchema } from '@/lib/validation';
 
 export type AddDspResponse = {
@@ -21,11 +20,12 @@ export type AddDspResponse = {
   addResult?: AddResult;
 };
 
-const rateLimiter = new RateLimiterMemory({ points: 1200, duration: 360 });
-
 export async function POST(request: NextRequest) {
+  const hdrs = await headers();
+  const identity = await resolveClientIdentity(hdrs);
+
   try {
-    await checkRateLimiter(rateLimiter, await headers(), 1);
+    await checkClientRateLimit(identity);
   } catch {
     return rateLimited();
   }
@@ -43,6 +43,13 @@ export async function POST(request: NextRequest) {
   }
 
   const { domain, selector } = parsed.data;
+
+  logger.info('api_request', {
+    clientType: identity.type,
+    clientId: identity.identifier,
+    endpoint: 'dsp',
+    domain: domain ?? undefined,
+  });
 
   try {
     const addResult = await addDomainSelectorPair(domain, selector, 'api');

--- a/src/app/api/jwk_set/route.ts
+++ b/src/app/api/jwk_set/route.ts
@@ -1,20 +1,29 @@
 import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
-import { RateLimiterMemory } from 'rate-limiter-flexible';
 
 import { rateLimited, serverError } from '@/lib/api-response';
+import {
+  checkClientRateLimit,
+  resolveClientIdentity,
+} from '@/lib/client-identity';
 import { getJWKeySetRecord } from '@/lib/db';
 import { logger } from '@/lib/logger';
-import { checkRateLimiter } from '@/lib/utils_server';
-
-const rateLimiter = new RateLimiterMemory({ points: 5, duration: 10 });
 
 export async function GET() {
+  const hdrs = await headers();
+  const identity = await resolveClientIdentity(hdrs);
+
   try {
-    await checkRateLimiter(rateLimiter, await headers(), 1);
+    await checkClientRateLimit(identity);
   } catch {
     return rateLimited();
   }
+
+  logger.info('api_request', {
+    clientType: identity.type,
+    clientId: identity.identifier,
+    endpoint: 'jwk_set',
+  });
 
   try {
     const JwkSet = await getJWKeySetRecord();

--- a/src/app/api/key/domain/route.ts
+++ b/src/app/api/key/domain/route.ts
@@ -1,23 +1,23 @@
 import { headers } from 'next/headers';
 import { type NextRequest, NextResponse } from 'next/server';
-import { RateLimiterMemory } from 'rate-limiter-flexible';
 
 import { type DomainSearchResults } from '@/app/api/key/route';
 import { rateLimited, serverError, validationError } from '@/lib/api-response';
+import {
+  checkClientRateLimit,
+  resolveClientIdentity,
+} from '@/lib/client-identity';
 import { findRecordsWithCache, type RecordWithSelector } from '@/lib/db';
 import { logger } from '@/lib/logger';
-import {
-  addDomainSelectorPair,
-  checkRateLimiter,
-  fetchDkimDnsRecord,
-} from '@/lib/utils_server';
+import { addDomainSelectorPair, fetchDkimDnsRecord } from '@/lib/utils_server';
 import { dspQuerySchema } from '@/lib/validation';
 
-const rateLimiter = new RateLimiterMemory({ points: 2000, duration: 1 });
-
 export async function GET(request: NextRequest) {
+  const hdrs = await headers();
+  const identity = await resolveClientIdentity(hdrs);
+
   try {
-    await checkRateLimiter(rateLimiter, await headers(), 1);
+    await checkClientRateLimit(identity);
   } catch {
     return rateLimited();
   }
@@ -30,6 +30,13 @@ export async function GET(request: NextRequest) {
   }
 
   const { domain, selector } = parsed.data;
+
+  logger.info('api_request', {
+    clientType: identity.type,
+    clientId: identity.identifier,
+    endpoint: 'key/domain',
+    domain: domain ?? undefined,
+  });
 
   try {
     // Fetch from database

--- a/src/app/api/key/route.ts
+++ b/src/app/api/key/route.ts
@@ -1,11 +1,13 @@
 import { headers } from 'next/headers';
 import { type NextRequest, NextResponse } from 'next/server';
-import { RateLimiterMemory } from 'rate-limiter-flexible';
 
 import { rateLimited, serverError, validationError } from '@/lib/api-response';
+import {
+  checkClientRateLimit,
+  resolveClientIdentity,
+} from '@/lib/client-identity';
 import { findRecords } from '@/lib/db';
 import { logger } from '@/lib/logger';
-import { checkRateLimiter } from '@/lib/utils_server';
 import { dspQuerySchema } from '@/lib/validation';
 
 export type DomainSearchResults = {
@@ -16,11 +18,12 @@ export type DomainSearchResults = {
   value: string;
 };
 
-const rateLimiter = new RateLimiterMemory({ points: 1000, duration: 1 });
-
 export async function GET(request: NextRequest) {
+  const hdrs = await headers();
+  const identity = await resolveClientIdentity(hdrs);
+
   try {
-    await checkRateLimiter(rateLimiter, await headers(), 1);
+    await checkClientRateLimit(identity);
   } catch {
     return rateLimited();
   }
@@ -33,6 +36,13 @@ export async function GET(request: NextRequest) {
   }
 
   const { domain, selector } = parsed.data;
+
+  logger.info('api_request', {
+    clientType: identity.type,
+    clientId: identity.identifier,
+    endpoint: 'key',
+    domain: domain ?? undefined,
+  });
 
   try {
     let records = await findRecords(domain);

--- a/src/lib/client-identity.ts
+++ b/src/lib/client-identity.ts
@@ -1,0 +1,145 @@
+import crypto from 'crypto';
+import { LRUCache } from 'lru-cache';
+import type { ReadonlyHeaders } from 'next/dist/server/web/spec-extension/adapters/headers';
+import { RateLimiterMemory } from 'rate-limiter-flexible';
+
+import type { ApiKey } from '@/generated/prisma/client';
+
+import { prisma } from './db';
+import { getClientIp } from './utils_server';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const DEFAULT_RATE_LIMIT = 100; // req/sec for anonymous origin / IP callers
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ClientIdentity = {
+  type: 'api_key' | 'origin' | 'ip';
+  identifier: string; // key name, origin string, or IP
+  rateLimit: number; // req/sec for this client
+};
+
+// ─── API Key Cache ────────────────────────────────────────────────────────────
+
+const apiKeyCache = new LRUCache<string, ApiKey>({
+  max: 200,
+  ttl: 5 * 60 * 1000, // 5 minutes
+});
+
+function hashApiKey(rawKey: string): string {
+  return crypto.createHash('sha256').update(rawKey).digest('hex');
+}
+
+async function lookupApiKey(rawKey: string): Promise<ApiKey | null> {
+  const hash = hashApiKey(rawKey);
+
+  const cached = apiKeyCache.get(hash);
+  if (cached) return cached;
+
+  const record = await prisma.apiKey.findFirst({
+    where: { keyHash: hash, isActive: true },
+  });
+
+  if (!record) return null;
+
+  apiKeyCache.set(hash, record);
+
+  // Fire-and-forget: update lastUsedAt
+  prisma.apiKey
+    .update({ where: { id: record.id }, data: { lastUsedAt: new Date() } })
+    .catch(() => {
+      // Ignore errors — this is best-effort
+    });
+
+  return record;
+}
+
+// ─── Per-Client Rate Limiters ─────────────────────────────────────────────────
+
+const clientLimiters = new Map<string, RateLimiterMemory>();
+
+function getLimiter(clientId: string, rateLimit: number): RateLimiterMemory {
+  const existing = clientLimiters.get(clientId);
+  if (existing) return existing;
+
+  const limiter = new RateLimiterMemory({
+    points: rateLimit,
+    duration: 1, // per second
+    keyPrefix: clientId,
+  });
+  clientLimiters.set(clientId, limiter);
+  return limiter;
+}
+
+// ─── Origin Extraction ────────────────────────────────────────────────────────
+
+function extractOrigin(headers: ReadonlyHeaders): string | null {
+  const origin = headers.get('origin');
+  if (origin) return origin.trim();
+
+  const referer = headers.get('referer');
+  if (referer) {
+    try {
+      const url = new URL(referer);
+      return `${url.protocol}//${url.host}`;
+    } catch {
+      // Invalid URL — ignore
+    }
+  }
+
+  return null;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Resolves the client identity from request headers.
+ * Priority: api_key > origin > ip
+ */
+export async function resolveClientIdentity(
+  headers: ReadonlyHeaders
+): Promise<ClientIdentity> {
+  // 1. API key
+  const rawKey = headers.get('x-api-key');
+  if (rawKey) {
+    const record = await lookupApiKey(rawKey);
+    if (record) {
+      return {
+        type: 'api_key',
+        identifier: record.name,
+        rateLimit: record.rateLimit,
+      };
+    }
+    // Invalid key: fall through to origin / IP
+  }
+
+  // 2. Origin header
+  const origin = extractOrigin(headers);
+  if (origin) {
+    return {
+      type: 'origin',
+      identifier: origin,
+      rateLimit: DEFAULT_RATE_LIMIT,
+    };
+  }
+
+  // 3. IP fallback
+  const ip = getClientIp(headers);
+  return {
+    type: 'ip',
+    identifier: ip,
+    rateLimit: DEFAULT_RATE_LIMIT,
+  };
+}
+
+/**
+ * Consumes 1 point from this client's per-client rate limiter.
+ * Throws RateLimiterRes if the limit is exceeded.
+ */
+export async function checkClientRateLimit(
+  identity: ClientIdentity
+): Promise<void> {
+  const limiter = getLimiter(identity.identifier, identity.rateLimit);
+  await limiter.consume(identity.identifier, 1);
+}


### PR DESCRIPTION
Replaces the single shared RateLimiterMemory per route with a per-client identity system

  - Add `ApiKey` Prisma model (keyHash, name, rateLimit, isActive, lastUsedAt) + migration
  - Add `src/lib/client-identity.ts`: resolves caller identity from x-api-key → Origin/Referer → IP, with LRU-cached DB lookups and per-client RateLimiterMemory instances
  - Update all four API routes (key, key/domain, dsp, jwk_set) to use resolveClientIdentity + checkClientRateLimit, and log api_request events with clientType, clientId, endpoint, and domain
  - Add `scripts/generate-api-key.ts` to provision new API clients