### PR TITLE
ci: add lint and build workflow, split build scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm prisma generate
-        env:
-          DATABASE_URL: postgresql://unused:unused@localhost/unused
       - name: Check formatting
         run: pnpm prettier:check
       - name: Check linting
@@ -36,10 +34,5 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm prisma generate
-        env:
-          DATABASE_URL: postgresql://unused:unused@localhost/unused
       - name: Run build
-        run: pnpm next build
-        env:
-          DATABASE_URL: postgresql://unused:unused@localhost/unused
+        run: pnpm build

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {
-    "build": "prisma generate && prisma migrate deploy && NODE_OPTIONS='--max-old-space-size=4096' next build",
+    "build": "prisma generate && next build",
+    "build:deploy": "prisma generate && prisma migrate deploy && NODE_OPTIONS='--max-old-space-size=4096' next build",
     "clean": "rm -rf node_modules && rm -rf .next",
     "dev": "pnpm run lint --fix && pnpm run prettier && next dev",
     "lint": "next lint --fix",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
     path: 'prisma/migrations',
   },
   datasource: {
-    url: env('DATABASE_URL'),
+    url: process.env.DATABASE_URL ?? 'postgresql://localhost/archive',
   },
 });


### PR DESCRIPTION
## Summary
- Add CI workflow: prettier check -> lint check -> build
- Split build into `build` (prisma generate + next build, works offline) and `build:deploy` (+ prisma migrate, needs DB)
- Make DATABASE_URL optional in prisma.config.ts so prisma generate works without a database connection
- Use latest GitHub Actions (checkout@v6, setup-node@v6, pnpm/action-setup@v6)
- Node version read from .nvmrc, pnpm version from packageManager field

## Render
Update build command to: `pnpm install --frozen-lockfile && pnpm build:deploy`

Generated with [Claude Code](https://claude.com/claude-code)