### PR TITLE
fix: QA feedback round 2 (REG-689)

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -19,11 +19,16 @@ export default function HomeClient({ stats }: HomeClientProps) {
   const [uniqueSelectors, setUniqueSelectors] = useState(0);
   const [DSP, setDSP] = useState(0);
   const [DKIMkey, setDKIMkey] = useState(0);
+  // True from the moment the user submits until the navigation to /search
+  // takes over. Drives the spinner inside the magnifier button so there's
+  // visible feedback during the brief "loading the search page" gap.
+  const [isNavigating, setIsNavigating] = useState(false);
 
   const handleSearch = (value: string) => {
     const trimmed = value.trim();
     if (!trimmed) return;
     analytics.capture('search', { query: trimmed, source: 'homepage' });
+    setIsNavigating(true);
     window.location.href = `/search?q=${encodeURIComponent(trimmed)}`;
   };
 
@@ -102,7 +107,10 @@ export default function HomeClient({ stats }: HomeClientProps) {
           <div className='justify-start self-stretch text-base leading-tight tracking-tight text-primary'>
             Search Domain
           </div>
-          <DomainSearchInput onSubmit={handleSearch} />
+          <DomainSearchInput
+            onSubmit={handleSearch}
+            isSearchLoading={isNavigating}
+          />
         </div>
         <div className='flex w-full flex-col items-start justify-start gap-3'>
           <div className='justify-start self-stretch leading-tight tracking-tight text-primary'>

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -1,23 +1,12 @@
 'use client';
 
-import {
-  ArrowRightIcon,
-  MagnifyingGlassIcon,
-  XIcon,
-} from '@phosphor-icons/react';
+import { ArrowRightIcon } from '@phosphor-icons/react';
 import Image from 'next/image';
 import Link from 'next/link';
-import {
-  SetStateAction,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { SetStateAction, useEffect, useState } from 'react';
 
-import { autocomplete } from '@/app/actions';
+import { DomainSearchInput } from '@/components/DomainSearchInput';
 import { AnimatedNumber } from '@/components/ui/animated-number';
-import { Input } from '@/components/ui/input';
 import { analytics } from '@/lib/analytics';
 import { type ArchiveStats } from '@/lib/db';
 
@@ -26,95 +15,17 @@ interface HomeClientProps {
 }
 
 export default function HomeClient({ stats }: HomeClientProps) {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [suggestions, setSuggestions] = useState<string[]>([]);
-  const [showSuggestions, setShowSuggestions] = useState(false);
-  const [selectedIndex, setSelectedIndex] = useState(-1);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const suggestionsRef = useRef<HTMLDivElement>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [uniqueDomains, setUniqueDomains] = useState(0);
   const [uniqueSelectors, setUniqueSelectors] = useState(0);
   const [DSP, setDSP] = useState(0);
   const [DKIMkey, setDKIMkey] = useState(0);
 
-  const handleSearch = (query?: string) => {
-    const value = (query ?? searchQuery).trim();
-    if (value) {
-      analytics.capture('search', { query: value, source: 'homepage' });
-      window.location.href = `/search?q=${encodeURIComponent(value)}`;
-    }
+  const handleSearch = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    analytics.capture('search', { query: trimmed, source: 'homepage' });
+    window.location.href = `/search?q=${encodeURIComponent(trimmed)}`;
   };
-
-  const fetchSuggestions = useCallback(async (query: string) => {
-    if (!query || query.length < 2) {
-      setSuggestions([]);
-      setShowSuggestions(false);
-      return;
-    }
-    try {
-      const results = await autocomplete(query);
-      setSuggestions(results);
-      setShowSuggestions(results.length > 0);
-    } catch {
-      setSuggestions([]);
-    }
-  }, []);
-
-  const handleInputChange = (value: string) => {
-    setSearchQuery(value);
-    setSelectedIndex(-1);
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => fetchSuggestions(value), 200);
-  };
-
-  const handleSuggestionClick = (suggestion: string) => {
-    setSearchQuery(suggestion);
-    setShowSuggestions(false);
-    handleSearch(suggestion);
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (showSuggestions && suggestions.length > 0) {
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        setSelectedIndex((prev) =>
-          prev < suggestions.length - 1 ? prev + 1 : prev
-        );
-        return;
-      }
-      if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : -1));
-        return;
-      }
-      if (e.key === 'Enter' && selectedIndex >= 0) {
-        e.preventDefault();
-        handleSuggestionClick(suggestions[selectedIndex]);
-        return;
-      }
-      if (e.key === 'Escape') {
-        setShowSuggestions(false);
-        return;
-      }
-    }
-    if (e.key === 'Enter') handleSearch();
-  };
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (
-        suggestionsRef.current &&
-        !suggestionsRef.current.contains(e.target as Node) &&
-        inputRef.current &&
-        !inputRef.current.contains(e.target as Node)
-      ) {
-        setShowSuggestions(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
 
   useEffect(() => {
     const timeoutIds: ReturnType<typeof setTimeout>[] = [];
@@ -191,67 +102,7 @@ export default function HomeClient({ stats }: HomeClientProps) {
           <div className='justify-start self-stretch text-base leading-tight tracking-tight text-primary'>
             Search Domain
           </div>
-          <div className='relative my-0.25 flex w-full items-center gap-2 rounded-lg border border-border px-3 py-2'>
-            <MagnifyingGlassIcon
-              size={16}
-              color='var(--secondary)'
-              weight='bold'
-            />
-            <div className='relative min-w-0 flex-1'>
-              <Input
-                ref={inputRef}
-                placeholder='Domain name'
-                size='search'
-                value={searchQuery}
-                onChange={(e) => handleInputChange(e.target.value)}
-                onKeyDown={handleKeyDown}
-                onFocus={() =>
-                  suggestions.length > 0 && setShowSuggestions(true)
-                }
-                className='flex-1 border-0 text-base leading-tight tracking-tight text-secondary outline-0'
-              />
-              {searchQuery && (
-                <button
-                  onClick={() => {
-                    setSearchQuery('');
-                    setSuggestions([]);
-                    setShowSuggestions(false);
-                  }}
-                  className='absolute top-1/2 right-0 -translate-y-1/2 hover:text-secondary focus:outline-none'
-                  aria-label='Clear search'
-                >
-                  <XIcon size={20} weight='bold' color='#606060' />
-                </button>
-              )}
-            </div>
-            <button
-              onClick={() => handleSearch()}
-              className='flex items-center rounded-md bg-primary px-3 py-1 text-sm text-background transition-opacity hover:opacity-80'
-            >
-              Search
-            </button>
-
-            {showSuggestions && suggestions.length > 0 && (
-              <div
-                ref={suggestionsRef}
-                className='absolute top-full left-0 z-50 mt-1 w-full rounded-lg border border-border bg-foreground shadow-lg'
-              >
-                {suggestions.map((suggestion, index) => (
-                  <button
-                    key={suggestion}
-                    onClick={() => handleSuggestionClick(suggestion)}
-                    className={`hover:bg-muted w-full px-3 py-2 text-left text-sm ${
-                      index === selectedIndex ? 'bg-muted' : ''
-                    } ${index === 0 ? 'rounded-t-lg' : ''} ${
-                      index === suggestions.length - 1 ? 'rounded-b-lg' : ''
-                    }`}
-                  >
-                    {suggestion}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
+          <DomainSearchInput onSubmit={handleSearch} />
         </div>
         <div className='flex w-full flex-col items-start justify-start gap-3'>
           <div className='justify-start self-stretch leading-tight tracking-tight text-primary'>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,12 @@
+import type { Metadata } from 'next';
+
 import { getArchiveStats } from '@/lib/db';
 
 export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'About',
+};
 
 export default async function AboutPage() {
   const stats = await getArchiveStats();

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -173,13 +173,24 @@ export async function searchDomain(
         })
       : [];
 
-  const exactIds = exactRecords.map((r) => r.id);
   const remainingSlots = SEARCH_PAGE_SIZE - exactRecords.length;
 
+  // Exclude the exact-match domain from the alphabetical stream on *every*
+  // page (not just the first). Without this, any exact-domain records that
+  // overflowed the priority cap on page 1 would reappear as duplicates on
+  // later pages — and totalCount would no longer match what's actually
+  // shown.
   const otherRecords = await prisma.dkimRecord.findMany({
     where: {
-      domainSelectorPair: domainFilter,
-      ...(exactIds.length > 0 ? { id: { notIn: exactIds } } : {}),
+      domainSelectorPair: {
+        ...domainFilter,
+        NOT: {
+          domain: {
+            equals: domainQuery,
+            mode: Prisma.QueryMode.insensitive,
+          },
+        },
+      },
     },
     include: { domainSelectorPair: true },
     orderBy: { domainSelectorPair: { domain: 'asc' } },

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -111,6 +111,8 @@ function transformToSearchResult(record: RecordWithSelector): SearchResult {
   };
 }
 
+const SEARCH_PAGE_SIZE = 50;
+
 // Main search function for frontend - returns all data (filtering done client-side)
 export async function searchDomain(
   domainQuery: string,
@@ -128,7 +130,7 @@ export async function searchDomain(
     },
     include: { domainSelectorPair: true },
     orderBy: { domainSelectorPair: { domain: 'asc' } },
-    take: 50,
+    take: SEARCH_PAGE_SIZE,
     ...(cursorIndex ? { cursor: { id: cursorIndex }, skip: 1 } : {}),
   });
 
@@ -139,7 +141,10 @@ export async function searchDomain(
   });
 
   const searchResults = filteredRecords.map(transformToSearchResult);
-  const nextCursor = records.length > 0 ? records[records.length - 1].id : null;
+  // Only signal "load more" when the page was actually full — otherwise the
+  // client wastes a roundtrip fetching an empty next page.
+  const nextCursor =
+    records.length === SEARCH_PAGE_SIZE ? records[records.length - 1].id : null;
 
   // Get total count
   const totalCount = await prisma.dkimRecord.count({

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -29,8 +29,32 @@ function buildDomainFilter(query: string): Prisma.DomainSelectorPairWhereInput {
 
 export type AutocompleteResults = string[];
 
+const AUTOCOMPLETE_LIMIT = 8;
+
 export async function autocomplete(query: string): Promise<string[]> {
   if (!query) return [];
+
+  // Always look up the exact match first. Without this, short domains
+  // like "x.com" get buried under the top-N alphabetical substring matches
+  // ("101x.com", "1031ex.com", ...) and never appear in the dropdown even
+  // though the API returns them.
+  const exactMatch = await prisma.domainSelectorPair.findFirst({
+    where: {
+      domain: { equals: query, mode: Prisma.QueryMode.insensitive },
+    },
+    select: { domain: true },
+  });
+
+  const remainingSlots = exactMatch
+    ? AUTOCOMPLETE_LIMIT - 1
+    : AUTOCOMPLETE_LIMIT;
+
+  const prependExact = (results: string[]): string[] => {
+    if (!exactMatch) return results;
+    const lowered = exactMatch.domain.toLowerCase();
+    const deduped = results.filter((d) => d.toLowerCase() !== lowered);
+    return [exactMatch.domain, ...deduped].slice(0, AUTOCOMPLETE_LIMIT);
+  };
 
   // Simple prefix search for short queries
   if (!query.includes('.') && !query.includes('-')) {
@@ -40,10 +64,10 @@ export async function autocomplete(query: string): Promise<string[]> {
         domain: { startsWith: query, mode: Prisma.QueryMode.insensitive },
       },
       orderBy: { domain: 'asc' },
-      take: 8,
+      take: remainingSlots,
       select: { domain: true },
     });
-    return dsps.map((d) => d.domain);
+    return prependExact(dsps.map((d) => d.domain));
   }
 
   // Multi-strategy search for queries with dots/dashes
@@ -51,12 +75,12 @@ export async function autocomplete(query: string): Promise<string[]> {
     distinct: ['domain'],
     where: buildDomainFilter(query),
     orderBy: { domain: 'asc' },
-    take: 8,
+    take: remainingSlots,
     select: { domain: true },
   });
 
   // Prioritize results that start with the query
-  return dsps
+  const sorted = dsps
     .map((d) => d.domain)
     .sort((a, b) => {
       const aStarts = a.toLowerCase().startsWith(query.toLowerCase());
@@ -65,6 +89,8 @@ export async function autocomplete(query: string): Promise<string[]> {
       if (!aStarts && bStarts) return 1;
       return a.localeCompare(b);
     });
+
+  return prependExact(sorted);
 }
 
 export type RecordWithSelector = DkimRecord & {
@@ -112,6 +138,7 @@ function transformToSearchResult(record: RecordWithSelector): SearchResult {
 }
 
 const SEARCH_PAGE_SIZE = 50;
+const EXACT_MATCH_PRIORITY_LIMIT = 10;
 
 // Main search function for frontend - returns all data (filtering done client-side)
 export async function searchDomain(
@@ -124,15 +151,43 @@ export async function searchDomain(
 
   const domainFilter = buildDomainFilter(domainQuery);
 
-  const records = await prisma.dkimRecord.findMany({
+  // On the first page, surface up to EXACT_MATCH_PRIORITY_LIMIT records
+  // for the exact-match domain. Without this, short domains like "x.com"
+  // are completely missing from results because the first 50 alphabetical
+  // substring matches ("101x.com", "1031ex.com", ...) consume the page
+  // before their own records ever appear.
+  const exactRecords =
+    cursorIndex === null
+      ? await prisma.dkimRecord.findMany({
+          where: {
+            domainSelectorPair: {
+              domain: {
+                equals: domainQuery,
+                mode: Prisma.QueryMode.insensitive,
+              },
+            },
+          },
+          include: { domainSelectorPair: true },
+          orderBy: { id: 'asc' },
+          take: EXACT_MATCH_PRIORITY_LIMIT,
+        })
+      : [];
+
+  const exactIds = exactRecords.map((r) => r.id);
+  const remainingSlots = SEARCH_PAGE_SIZE - exactRecords.length;
+
+  const otherRecords = await prisma.dkimRecord.findMany({
     where: {
       domainSelectorPair: domainFilter,
+      ...(exactIds.length > 0 ? { id: { notIn: exactIds } } : {}),
     },
     include: { domainSelectorPair: true },
     orderBy: { domainSelectorPair: { domain: 'asc' } },
-    take: SEARCH_PAGE_SIZE,
+    take: remainingSlots,
     ...(cursorIndex ? { cursor: { id: cursorIndex }, skip: 1 } : {}),
   });
+
+  const records = [...exactRecords, ...otherRecords];
 
   // Filter for records with public key (p= tag present and not empty)
   const filteredRecords = records.filter((r) => {
@@ -141,10 +196,13 @@ export async function searchDomain(
   });
 
   const searchResults = filteredRecords.map(transformToSearchResult);
-  // Only signal "load more" when the page was actually full — otherwise the
+  // Pagination cursor tracks the alphabetical (non-exact) stream. Only
+  // signal "load more" when that stream was actually full — otherwise the
   // client wastes a roundtrip fetching an empty next page.
   const nextCursor =
-    records.length === SEARCH_PAGE_SIZE ? records[records.length - 1].id : null;
+    otherRecords.length === remainingSlots && remainingSlots > 0
+      ? otherRecords[otherRecords.length - 1].id
+      : null;
 
   // Get total count
   const totalCount = await prisma.dkimRecord.count({

--- a/src/app/api-docs/layout.tsx
+++ b/src/app/api-docs/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'API Docs',
+};
+
+export default function ApiDocsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/contribute/DragAndDropFile.tsx
+++ b/src/app/contribute/DragAndDropFile.tsx
@@ -158,9 +158,6 @@ const DragAndDropFile = ({
                   Click to upload{' '}
                   <span className='text-secondary'>or drop here</span>
                 </p>
-                <p className='text-accent-foreground-blue underline'>
-                  How to get the PST/MBOX file?
-                </p>
               </div>
             </>
           )}

--- a/src/app/contribute/EmailUploader.tsx
+++ b/src/app/contribute/EmailUploader.tsx
@@ -404,6 +404,8 @@ const EmailUploader = ({
     }
   };
 
+  const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+
   const handleFileSelect = (mode: UploadMode) => (selected: File | null) => {
     if (!selected) {
       if (uploadMode === mode) {
@@ -412,6 +414,13 @@ const EmailUploader = ({
       }
       return;
     }
+    if (selected.size > MAX_UPLOAD_BYTES) {
+      setUploadError(
+        `File is larger than ${Math.round(MAX_UPLOAD_BYTES / 1024 / 1024)} MB. Please split it into smaller files.`
+      );
+      return;
+    }
+    setUploadError(null);
     analytics.capture('file_upload_start', {
       fileType: selected.name.split('.').pop(),
       mode,

--- a/src/app/contribute/EmailUploader.tsx
+++ b/src/app/contribute/EmailUploader.tsx
@@ -760,8 +760,10 @@ const EmailUploader = ({
           onClearLog={handleClearLog}
         />
       </div>
-      {/* Show "Start New Upload" when upload is completed (not processing/paused) */}
-      {!isProcessingEmails && !isPaused && logResults.length > 0 && (
+      {/* Show a way back whenever we're idle inside the processed-view —
+          covers the completed case, the paused-then-stopped case, and the
+          immediate-parse-error case where logResults is still empty. */}
+      {!isProcessingEmails && !isPaused && (
         <div className='flex justify-center self-stretch pt-2'>
           <Button
             onClick={handleNewUpload}
@@ -769,7 +771,7 @@ const EmailUploader = ({
             className='flex items-center gap-2'
           >
             <ArrowCounterClockwiseIcon size={16} weight='bold' />
-            Start New Upload
+            {logResults.length > 0 ? 'Start New Upload' : 'Choose Another File'}
           </Button>
         </div>
       )}

--- a/src/app/contribute/EmailUploader.tsx
+++ b/src/app/contribute/EmailUploader.tsx
@@ -50,6 +50,11 @@ const SCRAPER_README_URL =
 
 type UploadMode = 'mailbox' | 'tsv';
 
+const UPLOAD_TABS: { id: UploadMode; label: string }[] = [
+  { id: 'mailbox', label: 'Mailbox file' },
+  { id: 'tsv', label: 'TSV file' },
+];
+
 const EmailUploader = ({
   setIsDataFetching,
 }: {
@@ -57,6 +62,10 @@ const EmailUploader = ({
 }) => {
   const [file, setFile] = useState<File | null>(null);
   const [uploadMode, setUploadMode] = useState<UploadMode | null>(null);
+  // Which file-upload tab the user is currently looking at. Gmail isn't a
+  // tab — it's a distinct action button sitting next to the tabs that
+  // kicks off OAuth immediately.
+  const [activeTab, setActiveTab] = useState<UploadMode>('mailbox');
   const [fetchedEmails, setFetchedEmails] = useState<RawEmailResponse[]>([]);
   const [isFetchEmailLoading, setIsFetchEmailLoading] = useState(false);
   const [pageToken, setPageToken] = useState<string | null>(null);
@@ -406,6 +415,17 @@ const EmailUploader = ({
 
   const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
 
+  const handleTabChange = (next: UploadMode) => {
+    if (next === activeTab) return;
+    setActiveTab(next);
+    // Switching tabs starts a fresh upload session in the new mode — the
+    // previous file would be misleading (and the Process button would
+    // mismatch its label).
+    setFile(null);
+    setUploadMode(null);
+    setUploadError(null);
+  };
+
   const handleFileSelect = (mode: UploadMode) => (selected: File | null) => {
     if (!selected) {
       if (uploadMode === mode) {
@@ -466,62 +486,76 @@ const EmailUploader = ({
 
   const emailUploadOptions = (
     <div className='flex w-full flex-col items-center justify-center gap-6'>
-      <div className='flex w-full flex-col items-center justify-center gap-3'>
-        <Button
-          className='flex w-max items-center gap-2 px-6 text-base leading-none font-semibold'
-          onClick={() => {
-            analytics.capture('gmail_connect');
-            setIsFetchEmailLoading(true);
-            setFile(null);
-            setUploadMode(null);
-            signIn('google');
-          }}
-        >
-          <Image
-            src='/assets/gmailIcon.png'
-            alt='Google Logo'
-            width={16}
-            height={16}
-          />
-          Connect Gmail Account
-        </Button>
-        <div className='flex w-full items-center gap-3'>
-          <Separator className='flex-1' />
-          <span className='text-base font-semibold text-secondary'>OR</span>
-          <Separator className='flex-1 rotate-180' />
+      <div className='flex w-full flex-col items-center justify-center gap-6'>
+        {/* Three contribution options side by side: Gmail kicks off OAuth
+            on click; Mailbox / TSV are tabs that swap the dropzone below.
+            Switching tabs clears any in-progress file selection (see
+            handleTabChange). */}
+        <div className='flex flex-row justify-center gap-2'>
+          <Button
+            onClick={() => {
+              analytics.capture('gmail_connect');
+              setIsFetchEmailLoading(true);
+              setFile(null);
+              setUploadMode(null);
+              signIn('google');
+            }}
+            className='flex h-auto cursor-pointer items-center gap-2 rounded-lg border-0 bg-background px-6 py-2 leading-tight font-normal tracking-tight text-primary hover:opacity-90'
+          >
+            <Image
+              src='/assets/gmailIcon.png'
+              alt='Google Logo'
+              width={16}
+              height={16}
+            />
+            Gmail
+          </Button>
+          {UPLOAD_TABS.map((tab) => (
+            <Button
+              key={tab.id}
+              onClick={() => handleTabChange(tab.id)}
+              className={`h-auto cursor-pointer rounded-lg border-0 px-6 py-2 leading-tight font-normal tracking-tight ${
+                activeTab === tab.id
+                  ? 'bg-selected text-background hover:opacity-90'
+                  : 'bg-background text-primary hover:opacity-90'
+              }`}
+            >
+              {tab.label}
+            </Button>
+          ))}
         </div>
 
-        {/* Mailbox upload — we extract DKIM pairs from each message. */}
-        {uploadSectionLabel(
-          'Upload mailbox file (.mbox or .eml)',
-          'Drop a Gmail Takeout / Apple Mail / Thunderbird export (.mbox) or a single saved email (.eml). We read each message and extract its DKIM domain + selector pairs locally before uploading them.',
-          SCRAPER_README_URL,
-          'How to export your mailbox?'
+        {activeTab === 'mailbox' && (
+          <>
+            {uploadSectionLabel(
+              'Upload mailbox file (.mbox or .eml)',
+              'Drop a Gmail Takeout / Apple Mail / Thunderbird export (.mbox) or a single saved email (.eml). We read each message and extract its DKIM domain + selector pairs locally before uploading them.',
+              SCRAPER_README_URL,
+              'How to export your mailbox?'
+            )}
+            <DragAndDropFile
+              accept='.mbox,.eml'
+              file={uploadMode === 'mailbox' ? file : null}
+              setFile={handleFileSelect('mailbox')}
+            />
+          </>
         )}
-        <DragAndDropFile
-          accept='.mbox,.eml'
-          file={uploadMode === 'mailbox' ? file : null}
-          setFile={handleFileSelect('mailbox')}
-        />
 
-        <div className='flex w-full items-center gap-3'>
-          <Separator className='flex-1' />
-          <span className='text-base font-semibold text-secondary'>OR</span>
-          <Separator className='flex-1 rotate-180' />
-        </div>
-
-        {/* TSV upload — pre-extracted pairs (e.g. from the legacy scraper). */}
-        {uploadSectionLabel(
-          'Upload TSV file (pre-extracted pairs)',
-          "A TSV file with two columns: domain and selector. This is what the old archive's mbox_scraper.py / pst_scraper.py scripts produce locally — useful if you want to keep your mailbox off our servers.",
-          SCRAPER_README_URL,
-          'How to produce the TSV?'
+        {activeTab === 'tsv' && (
+          <>
+            {uploadSectionLabel(
+              'Upload TSV file (pre-extracted pairs)',
+              "A TSV file with two columns: domain and selector. This is what the old archive's mbox_scraper.py / pst_scraper.py scripts produce locally — useful if you want to keep your mailbox off our servers.",
+              SCRAPER_README_URL,
+              'How to produce the TSV?'
+            )}
+            <DragAndDropFile
+              accept='.tsv'
+              file={uploadMode === 'tsv' ? file : null}
+              setFile={handleFileSelect('tsv')}
+            />
+          </>
         )}
-        <DragAndDropFile
-          accept='.tsv'
-          file={uploadMode === 'tsv' ? file : null}
-          setFile={handleFileSelect('tsv')}
-        />
 
         {uploadError && !file && (
           <div className='w-full text-sm text-destructive'>{uploadError}</div>

--- a/src/app/contribute/EmailUploader.tsx
+++ b/src/app/contribute/EmailUploader.tsx
@@ -523,6 +523,10 @@ const EmailUploader = ({
           setFile={handleFileSelect('tsv')}
         />
 
+        {uploadError && !file && (
+          <div className='w-full text-sm text-destructive'>{uploadError}</div>
+        )}
+
         {/* Process File button - shown after file is uploaded */}
         {file && (
           <Button

--- a/src/app/contribute/EmailUploader.tsx
+++ b/src/app/contribute/EmailUploader.tsx
@@ -495,6 +495,12 @@ const EmailUploader = ({
           setFile={handleFileSelect('mailbox')}
         />
 
+        <div className='flex w-full items-center gap-3'>
+          <Separator className='flex-1' />
+          <span className='text-base font-semibold text-secondary'>OR</span>
+          <Separator className='flex-1 rotate-180' />
+        </div>
+
         {/* TSV upload — pre-extracted pairs (e.g. from the legacy scraper). */}
         {uploadSectionLabel(
           'Upload TSV file (pre-extracted pairs)',

--- a/src/app/contribute/EmailUploader.tsx
+++ b/src/app/contribute/EmailUploader.tsx
@@ -23,13 +23,20 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import Loader from '@/components/ui/loader';
 import { Separator } from '@/components/ui/separator';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { RawEmailResponse } from '@/hooks/useGmailClient';
 import { fetchEmailList, fetchEmailsRaw } from '@/hooks/useGmailClient';
 import { analytics } from '@/lib/analytics';
 import {
-  getDkimSigsArray,
+  type DomainSelectorPair,
   getFileContent,
-  parseDkimTagListV2,
+  parseMailboxPairs,
+  parseTsvPairs,
 } from '@/lib/utils';
 
 import Calendar from '../search/Calendar';
@@ -38,12 +45,18 @@ import ProcessedLogs, { type LogResultItem } from './ProcessedLogs';
 
 const MAX_EMPTY_PAGE_RETRIES = 5;
 
+const SCRAPER_README_URL =
+  'https://github.com/zkemail/archive.zk.email?tab=readme-ov-file#mailbox_scraper';
+
+type UploadMode = 'mailbox' | 'tsv';
+
 const EmailUploader = ({
   setIsDataFetching,
 }: {
   setIsDataFetching: Dispatch<SetStateAction<boolean>>;
 }) => {
   const [file, setFile] = useState<File | null>(null);
+  const [uploadMode, setUploadMode] = useState<UploadMode | null>(null);
   const [fetchedEmails, setFetchedEmails] = useState<RawEmailResponse[]>([]);
   const [isFetchEmailLoading, setIsFetchEmailLoading] = useState(false);
   const [pageToken, setPageToken] = useState<string | null>(null);
@@ -306,13 +319,53 @@ const EmailUploader = ({
     setApiPageToken(null);
     setIsDataFetching(false);
     setFile(null);
+    setUploadMode(null);
   };
 
-  // Process uploaded .eml file - extract DKIM and call /api/dsp
-  const handleProcessFile = async () => {
-    if (!file) return;
+  // Submit a list of pre-extracted {domain, selector} pairs to /api/dsp,
+  // streaming the log + count UI as each one resolves. Shared between the
+  // mailbox (.mbox / .eml) and TSV upload paths — the only difference is
+  // which parser produced the list.
+  const submitPairs = async (
+    pairs: DomainSelectorPair[],
+    source: UploadMode
+  ) => {
+    setTotalMessages(pairs.length);
+    for (let i = 0; i < pairs.length; i++) {
+      const { domain, selector } = pairs[i];
+      setProcessedCount(i + 1);
+      try {
+        const response = await fetch('/api/dsp', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ domain, selector }),
+        });
+        const data: AddDspResponse = await response.json();
+        const logItem: LogResultItem = {
+          id: `${source}-${Date.now()}-${i}-${domain}-${selector}`,
+          domain,
+          selector,
+          timestamp: new Date().toISOString(),
+          isAdded: data.addResult?.added ?? false,
+          isUpdated:
+            (data.addResult?.already_in_db ?? false) &&
+            !(data.addResult?.added ?? false),
+        };
+        setLogResults((prev) => [...prev, logItem]);
+        if (data.addResult?.added) {
+          setAddedCount((prev) => prev + 1);
+        }
+      } catch (err) {
+        console.error(`Error adding ${domain}/${selector}:`, err);
+        // Continue with next pair
+      }
+    }
+  };
 
-    analytics.capture('file_process_start', { source: 'file_upload' });
+  const handleProcessFile = async () => {
+    if (!file || !uploadMode) return;
+
+    analytics.capture('file_process_start', { source: uploadMode });
     setUploadStarted(true);
     setIsProcessingEmails(true);
     setIsDataFetching(true);
@@ -327,59 +380,20 @@ const EmailUploader = ({
         throw new Error('Could not read file content');
       }
 
-      // Extract DKIM signatures from email
-      const dkimSigs = getDkimSigsArray(content);
-      if (dkimSigs.length === 0) {
-        throw new Error('No DKIM signatures found in email');
+      const pairs =
+        uploadMode === 'tsv'
+          ? parseTsvPairs(content)
+          : parseMailboxPairs(content);
+
+      if (pairs.length === 0) {
+        throw new Error(
+          uploadMode === 'tsv'
+            ? 'No domain/selector pairs found in TSV file'
+            : 'No DKIM signatures found in mailbox file'
+        );
       }
 
-      setTotalMessages(dkimSigs.length);
-
-      // Process each DKIM signature
-      for (let i = 0; i < dkimSigs.length; i++) {
-        const sig = dkimSigs[i];
-        const parsed = parseDkimTagListV2(sig);
-        const domain = parsed['d'];
-        const selector = parsed['s'];
-
-        if (!domain || !selector) {
-          console.warn('Missing domain or selector in DKIM signature:', sig);
-          continue;
-        }
-
-        setProcessedCount(i + 1);
-
-        try {
-          const response = await fetch('/api/dsp', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ domain, selector }),
-          });
-
-          const data: AddDspResponse = await response.json();
-
-          const logItem: LogResultItem = {
-            id: `file-${Date.now()}-${i}-${domain}-${selector}`,
-            domain,
-            selector,
-            timestamp: new Date().toISOString(),
-            isAdded: data.addResult?.added ?? false,
-            isUpdated:
-              (data.addResult?.already_in_db ?? false) &&
-              !(data.addResult?.added ?? false),
-          };
-
-          setLogResults((prev) => [...prev, logItem]);
-
-          if (data.addResult?.added) {
-            setAddedCount((prev) => prev + 1);
-          }
-        } catch (err) {
-          console.error(`Error adding ${domain}/${selector}:`, err);
-          // Continue with next signature
-        }
-      }
-
+      await submitPairs(pairs, uploadMode);
       setIsProcessingEmails(false);
     } catch (error) {
       console.error('Error processing file:', error);
@@ -390,6 +404,57 @@ const EmailUploader = ({
     }
   };
 
+  const handleFileSelect = (mode: UploadMode) => (selected: File | null) => {
+    if (!selected) {
+      if (uploadMode === mode) {
+        setFile(null);
+        setUploadMode(null);
+      }
+      return;
+    }
+    analytics.capture('file_upload_start', {
+      fileType: selected.name.split('.').pop(),
+      mode,
+    });
+    setFile(selected);
+    setUploadMode(mode);
+  };
+
+  const uploadSectionLabel = (
+    label: string,
+    tooltip: string,
+    helpHref: string,
+    helpLabel: string
+  ) => (
+    <div className='flex w-full flex-col gap-1'>
+      <div className='inline-flex items-center gap-2 self-start text-base leading-tight font-medium text-primary'>
+        <span>{label}</span>
+        <TooltipProvider delayDuration={0}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type='button'
+                aria-label='Help'
+                className='cursor-help text-secondary'
+              >
+                <QuestionIcon size={16} color='#606060' />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className='max-w-xs'>{tooltip}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+      <a
+        href={helpHref}
+        target='_blank'
+        rel='noreferrer noopener'
+        className='self-start text-sm text-accent-foreground-blue underline'
+      >
+        {helpLabel}
+      </a>
+    </div>
+  );
+
   const emailUploadOptions = (
     <div className='flex w-full flex-col items-center justify-center gap-6'>
       <div className='flex w-full flex-col items-center justify-center gap-3'>
@@ -399,6 +464,7 @@ const EmailUploader = ({
             analytics.capture('gmail_connect');
             setIsFetchEmailLoading(true);
             setFile(null);
+            setUploadMode(null);
             signIn('google');
           }}
         >
@@ -415,37 +481,33 @@ const EmailUploader = ({
           <span className='text-base font-semibold text-secondary'>OR</span>
           <Separator className='flex-1 rotate-180' />
         </div>
-        <div className='inline-flex gap-2 self-start text-base leading-tight font-medium text-primary'>
-          <div>Upload PST/MBOX file</div>
-          <QuestionIcon size={16} color='#606060' />
-        </div>
+
+        {/* Mailbox upload — we extract DKIM pairs from each message. */}
+        {uploadSectionLabel(
+          'Upload mailbox file (.mbox or .eml)',
+          'Drop a Gmail Takeout / Apple Mail / Thunderbird export (.mbox) or a single saved email (.eml). We read each message and extract its DKIM domain + selector pairs locally before uploading them.',
+          SCRAPER_README_URL,
+          'How to export your mailbox?'
+        )}
         <DragAndDropFile
-          accept='.eml'
-          file={file}
-          tooltipComponent={
-            <div className='border-grey-500 w-[380px] rounded-2xl border bg-white p-2'>
-              <Image
-                src='/assets/emlInfo.svg'
-                alt='emlInfo'
-                width={360}
-                height={80}
-              />
-              <p className='text-grey-700 mt-3 text-base font-medium'>
-                The test .eml file is a sample email used to check if all the
-                provided patterns (regex) work correctly. This helps confirm
-                everything is set up properly before blueprint creation. We
-                always store this file locally and never send it to our server.
-              </p>
-            </div>
-          }
-          setFile={(e) => {
-            if (!e) return;
-            analytics.capture('file_upload_start', {
-              fileType: e.name.split('.').pop(),
-            });
-            setFile(e);
-          }}
+          accept='.mbox,.eml'
+          file={uploadMode === 'mailbox' ? file : null}
+          setFile={handleFileSelect('mailbox')}
         />
+
+        {/* TSV upload — pre-extracted pairs (e.g. from the legacy scraper). */}
+        {uploadSectionLabel(
+          'Upload TSV file (pre-extracted pairs)',
+          "A TSV file with two columns: domain and selector. This is what the old archive's mbox_scraper.py / pst_scraper.py scripts produce locally — useful if you want to keep your mailbox off our servers.",
+          SCRAPER_README_URL,
+          'How to produce the TSV?'
+        )}
+        <DragAndDropFile
+          accept='.tsv'
+          file={uploadMode === 'tsv' ? file : null}
+          setFile={handleFileSelect('tsv')}
+        />
+
         {/* Process File button - shown after file is uploaded */}
         {file && (
           <Button
@@ -454,7 +516,7 @@ const EmailUploader = ({
           >
             <div className='flex w-auto items-center justify-center gap-2'>
               <EnvelopeIcon size={16} weight='bold' />
-              <div>Process Email File</div>
+              <div>Process {uploadMode === 'tsv' ? 'TSV' : 'Mailbox'} File</div>
             </div>
           </Button>
         )}
@@ -472,12 +534,13 @@ const EmailUploader = ({
           </AccordionTrigger>
           <AccordionContent className='flex flex-col gap-4 px-4 pt-2'>
             <div className='text-base leading-tight font-medium text-secondary'>
-              When you sign in with your Gmail account and press Start, the site
-              will extract the DKIM-Signature field from each email message in
-              your Gmail account. A signature can look something like this:
+              When you sign in with your Gmail account or upload a mailbox file,
+              the site reads the DKIM-Signature header from each email message
+              and extracts only the domain and selector. A signature can look
+              something like this:
             </div>
             <div className='rounded-lg border border-border p-4 text-xs leading-none font-light'>
-              DKIM-Signature: v=1; a=rsa-sha256; d=australia.net; s=brisbane;
+              DKIM-Signature: v=1; a=rsa-sha256; d=example.net; s=brisbane;
               c=relaxed/simple; q=dns/txt; i=foo@eng.example.net; t=1117574938;
               x=1118006938; l=200; h=from:to:subject:date:keywords:keywords;
               z=From:foo@eng.example.net|To:joe@example.com|
@@ -487,7 +550,7 @@ const EmailUploader = ({
               VoG4ZHRNiYzR
             </div>
             <div className='text-base leading-tight font-medium text-secondary'>
-              In the example above, the domain is australianet and the selector
+              In the example above, the domain is example.net and the selector
               is brisbane. These are the values that will be extracted and
               uploaded to the archive.
             </div>

--- a/src/app/contribute/layout.tsx
+++ b/src/app/contribute/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Contribute',
+};
+
+export default function ContributeLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -19,8 +19,8 @@ export default function Home() {
           </div>
           <div className='flex justify-start text-[clamp(1rem,1.39vw,1.25rem)] leading-5 font-semibold tracking-tight text-white'>
             <span className='whitespace-normal'>
-              By uploading DKIM pairs from your Gmail account or from a TSV
-              file.
+              By uploading DKIM pairs from your Gmail account, a mailbox file,
+              or a TSV file.
             </span>
           </div>
         </div>

--- a/src/app/jwt/layout.tsx
+++ b/src/app/jwt/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'JWT Keys',
+};
+
+export default function JwtLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,10 @@ import { NextAuthProvider } from './session-provider';
 const fustat = Fustat({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: 'ZK Email',
+  title: {
+    template: '%s | ZK Email',
+    default: 'ZK Email',
+  },
   description: '',
   icons: {
     icon: [

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,14 @@
+import type { Metadata } from 'next';
+
 import { getArchiveStats } from '@/lib/db';
 
 import HomeClient from './HomeClient';
 
 export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: { absolute: 'DKIM Archive | ZK Email' },
+};
 
 export default async function Home() {
   const stats = await getArchiveStats();

--- a/src/app/search/ActivityChart.tsx
+++ b/src/app/search/ActivityChart.tsx
@@ -207,7 +207,7 @@ const ActivityChart = ({
                   cy?: number;
                   index?: number;
                   payload?: { activity: number | null };
-                  key?: string | number;
+                  key?: React.Key | null;
                 }) => {
                   const { cx, cy, payload, index, key } = dotProps;
                   if (

--- a/src/app/search/ActivityChart.tsx
+++ b/src/app/search/ActivityChart.tsx
@@ -196,7 +196,39 @@ const ActivityChart = ({
                 stroke='#22c55e'
                 strokeWidth={1}
                 fill='url(#activityGradient)'
-                dot={false}
+                // Recharts <Area> can't render a single isolated non-null
+                // point — for selectors with a sub-bucket activity window
+                // (e.g. first and last seen in the same month) the area
+                // would otherwise be completely invisible. Draw an explicit
+                // green dot in that case so short-lived selectors still
+                // show up on the chart.
+                dot={(dotProps: {
+                  cx?: number;
+                  cy?: number;
+                  index?: number;
+                  payload?: { activity: number | null };
+                  key?: string | number;
+                }) => {
+                  const { cx, cy, payload, index, key } = dotProps;
+                  if (
+                    cx === undefined ||
+                    cy === undefined ||
+                    index === undefined ||
+                    !payload ||
+                    payload.activity === null
+                  ) {
+                    return <g key={key} />;
+                  }
+                  const prev = data[index - 1];
+                  const next = data[index + 1];
+                  const isIsolated =
+                    (!prev || prev.activity === null) &&
+                    (!next || next.activity === null);
+                  if (!isIsolated) return <g key={key} />;
+                  return (
+                    <circle key={key} cx={cx} cy={cy} r={4} fill='#22c55e' />
+                  );
+                }}
                 connectNulls={false}
               />
             </AreaChart>

--- a/src/app/search/SearchAndFilterSection.tsx
+++ b/src/app/search/SearchAndFilterSection.tsx
@@ -1,18 +1,13 @@
-import {
-  MagnifyingGlassIcon,
-  SlidersHorizontalIcon,
-  XIcon,
-} from '@phosphor-icons/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { SlidersHorizontalIcon } from '@phosphor-icons/react';
+import { useState } from 'react';
 
-import { autocomplete } from '@/app/actions';
+import { DomainSearchInput } from '@/components/DomainSearchInput';
 import { Button } from '@/components/ui/button';
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
-import { Input } from '@/components/ui/input';
 import { analytics } from '@/lib/analytics';
 
 import Calendar from './Calendar';
@@ -25,6 +20,7 @@ type SearchAndFilterSectionProps = {
     fromDate: Date | undefined,
     toDate: Date | undefined
   ) => void;
+  isSearchLoading?: boolean;
 };
 
 export function SearchAndFilterSection({
@@ -32,117 +28,12 @@ export function SearchAndFilterSection({
   onSearchChange,
   onFilterChange,
   onDateRangeChange,
+  isSearchLoading = false,
 }: SearchAndFilterSectionProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [searchValue, setSearchValue] = useState(initialQuery);
   const [filterValue, setFilterValue] = useState('all');
   const [fromDate, setFromDate] = useState<Date | undefined>(undefined);
   const [toDate, setToDate] = useState<Date | undefined>(undefined);
-
-  // Autocomplete state
-  const [suggestions, setSuggestions] = useState<string[]>([]);
-  const [showSuggestions, setShowSuggestions] = useState(false);
-  const [selectedIndex, setSelectedIndex] = useState(-1);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const suggestionsRef = useRef<HTMLDivElement>(null);
-  const debounceRef = useRef<NodeJS.Timeout | null>(null);
-
-  useEffect(() => {
-    setSearchValue(initialQuery);
-  }, [initialQuery]);
-
-  // Fetch autocomplete suggestions with debounce
-  const fetchSuggestions = useCallback(async (query: string) => {
-    if (!query || query.length < 2) {
-      setSuggestions([]);
-      return;
-    }
-
-    try {
-      const results = await autocomplete(query);
-      setSuggestions(results);
-      setShowSuggestions(results.length > 0);
-    } catch (err) {
-      console.error('Autocomplete error:', err);
-      setSuggestions([]);
-    }
-  }, []);
-
-  const handleSearchChange = (value: string) => {
-    setSearchValue(value);
-    setSelectedIndex(-1);
-
-    // Debounce autocomplete
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-    }
-    debounceRef.current = setTimeout(() => {
-      fetchSuggestions(value);
-    }, 200);
-
-    // Debounce search callback
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-    }
-    debounceRef.current = setTimeout(() => {
-      fetchSuggestions(value);
-      onSearchChange?.(value);
-    }, 300);
-  };
-
-  const handleSuggestionClick = (suggestion: string) => {
-    setSearchValue(suggestion);
-    setShowSuggestions(false);
-    setSuggestions([]);
-    onSearchChange?.(suggestion);
-    analytics.capture('autocomplete_selected', { domain: suggestion });
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (!showSuggestions || suggestions.length === 0) return;
-
-    switch (e.key) {
-      case 'ArrowDown':
-        e.preventDefault();
-        setSelectedIndex((prev) =>
-          prev < suggestions.length - 1 ? prev + 1 : prev
-        );
-        break;
-      case 'ArrowUp':
-        e.preventDefault();
-        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : -1));
-        break;
-      case 'Enter':
-        e.preventDefault();
-        if (selectedIndex >= 0) {
-          handleSuggestionClick(suggestions[selectedIndex]);
-        } else {
-          setShowSuggestions(false);
-          onSearchChange?.(searchValue);
-        }
-        break;
-      case 'Escape':
-        setShowSuggestions(false);
-        break;
-    }
-  };
-
-  // Close suggestions when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (
-        suggestionsRef.current &&
-        !suggestionsRef.current.contains(e.target as Node) &&
-        inputRef.current &&
-        !inputRef.current.contains(e.target as Node)
-      ) {
-        setShowSuggestions(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
 
   const handleFilterChange = (value: string) => {
     setFilterValue(value);
@@ -172,13 +63,6 @@ export function SearchAndFilterSection({
     }
   };
 
-  const handleClear = () => {
-    setSearchValue('');
-    setSuggestions([]);
-    setShowSuggestions(false);
-    onSearchChange?.('');
-  };
-
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen} className='w-full'>
       <div className='flex flex-col items-start justify-start gap-2 self-stretch'>
@@ -186,54 +70,11 @@ export function SearchAndFilterSection({
           Search
         </div>
         <div className='flex w-full items-center gap-2'>
-          <div className='relative flex w-full items-center gap-2 rounded-lg border border-border px-3 py-2'>
-            <MagnifyingGlassIcon size={16} color='#606060' weight='bold' />
-            <div className='relative min-w-0 flex-1'>
-              <Input
-                ref={inputRef}
-                placeholder='Domain name'
-                value={searchValue}
-                onChange={(e) => handleSearchChange(e.target.value)}
-                onKeyDown={handleKeyDown}
-                onFocus={() =>
-                  suggestions.length > 0 && setShowSuggestions(true)
-                }
-                className='h-auto w-full border-0 bg-transparent p-0 text-base leading-tight tracking-tight ring-0 outline-0 focus-visible:ring-0 focus-visible:ring-offset-0'
-              />
-              {searchValue && (
-                <button
-                  onClick={handleClear}
-                  className='absolute top-1/2 right-0 -translate-y-1/2 hover:text-secondary focus:outline-none'
-                  aria-label='Clear search'
-                >
-                  <XIcon size={20} weight='bold' color='#606060' />
-                </button>
-              )}
-            </div>
-
-            {/* Autocomplete dropdown */}
-            {showSuggestions && suggestions.length > 0 && (
-              <div
-                ref={suggestionsRef}
-                className='absolute top-full left-0 z-50 mt-1 w-full rounded-lg border border-border bg-foreground shadow-lg'
-              >
-                {suggestions.map((suggestion, index) => (
-                  <button
-                    key={suggestion}
-                    onClick={() => handleSuggestionClick(suggestion)}
-                    className={`hover:bg-muted w-full px-3 py-2 text-left text-sm ${
-                      index === selectedIndex ? 'bg-muted' : ''
-                    } ${index === 0 ? 'rounded-t-lg' : ''} ${
-                      index === suggestions.length - 1 ? 'rounded-b-lg' : ''
-                    }`}
-                  >
-                    {suggestion}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-
+          <DomainSearchInput
+            initialQuery={initialQuery}
+            onSubmit={(value) => onSearchChange?.(value)}
+            isSearchLoading={isSearchLoading}
+          />
           <CollapsibleTrigger asChild>
             <Button
               variant='ghost'

--- a/src/app/search/SelectorDetails.tsx
+++ b/src/app/search/SelectorDetails.tsx
@@ -112,7 +112,9 @@ const SelectorDetails = ({ data }: SelectorDetailsProps) => {
     {}
   );
 
-  const domains = Object.keys(groupedByDomain).sort();
+  // Preserve server order (exact-match domain first, then alphabetical)
+  // rather than re-sorting alphabetically and burying the exact match.
+  const domains = Object.keys(groupedByDomain);
 
   return (
     <div className='flex w-full flex-col gap-6'>

--- a/src/app/search/layout.tsx
+++ b/src/app/search/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Search',
+};
+
+export default function SearchLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
 
 import { type SearchFilters } from '@/app/actions';
@@ -10,11 +10,11 @@ import { DomainSearchResults } from '@/components/DomainSearchResult';
 import { SearchAndFilterSection } from './SearchAndFilterSection';
 
 export default function Home() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const initialQuery = searchParams.get('q') ?? '';
 
   const [searchQuery, setSearchQuery] = useState(initialQuery);
+  const [isSearchLoading, setIsSearchLoading] = useState(false);
   const [statusFilter, setStatusFilter] = useState<
     'all' | 'active' | 'expired'
   >('all');
@@ -23,14 +23,15 @@ export default function Home() {
 
   const handleSearchChange = (value: string) => {
     setSearchQuery(value);
-    // Update URL without page reload
+    // Keep URL in sync without triggering an RSC navigation per keystroke.
     const params = new URLSearchParams(searchParams.toString());
     if (value) {
       params.set('q', value);
     } else {
       params.delete('q');
     }
-    router.replace(`/search?${params.toString()}`);
+    const qs = params.toString();
+    window.history.replaceState(null, '', qs ? `/search?${qs}` : '/search');
   };
 
   const handleFilterChange = (value: string) => {
@@ -82,10 +83,15 @@ export default function Home() {
             onSearchChange={handleSearchChange}
             onFilterChange={handleFilterChange}
             onDateRangeChange={handleDateRangeChange}
+            isSearchLoading={isSearchLoading}
           />
         </div>
         <div className='flex flex-col items-start justify-start gap-2 self-stretch'>
-          <DomainSearchResults domainQuery={searchQuery} filters={filters} />
+          <DomainSearchResults
+            domainQuery={searchQuery}
+            filters={filters}
+            onLoadingChange={setIsSearchLoading}
+          />
         </div>
       </div>
     </div>

--- a/src/components/DomainSearchInput.tsx
+++ b/src/components/DomainSearchInput.tsx
@@ -47,7 +47,13 @@ export function DomainSearchInput({
   const suppressAutocompleteRef = useRef(false);
 
   useEffect(() => {
+    // Keep the committed value in sync with the input when initialQuery
+    // changes (e.g. browser back/forward updates `?q=`). Without this,
+    // searchValue resets but committedValue lags, isDirty flips true, and
+    // the "Press Enter to search" hint appears even though the input
+    // matches the URL.
     setSearchValue(initialQuery);
+    setCommittedValue(initialQuery);
   }, [initialQuery]);
 
   // True when the visible input no longer matches the last committed

--- a/src/components/DomainSearchInput.tsx
+++ b/src/components/DomainSearchInput.tsx
@@ -1,0 +1,312 @@
+'use client';
+
+import { MagnifyingGlassIcon, XIcon } from '@phosphor-icons/react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { autocomplete } from '@/app/actions';
+import { Input } from '@/components/ui/input';
+import { analytics } from '@/lib/analytics';
+
+type DomainSearchInputProps = {
+  initialQuery?: string;
+  // Fired when the user commits a search (Enter, magnifier-click, picking
+  // an autocomplete suggestion, or clearing the input back to empty).
+  onSubmit: (value: string) => void;
+  // True while the committed search is in flight. Drives the spinner inside
+  // the magnifier button.
+  isSearchLoading?: boolean;
+  placeholder?: string;
+};
+
+export function DomainSearchInput({
+  initialQuery = '',
+  onSubmit,
+  isSearchLoading = false,
+  placeholder = 'Domain name',
+}: DomainSearchInputProps) {
+  const [searchValue, setSearchValue] = useState(initialQuery);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [isAutocompleteFetching, setIsAutocompleteFetching] = useState(false);
+  // Tracks the value most recently committed so the "Press Enter to search"
+  // hint only shows when the input differs.
+  const [committedValue, setCommittedValue] = useState(initialQuery);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const suggestionsRef = useRef<HTMLDivElement>(null);
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+  // Serialize autocomplete: at most one request in flight; latest queued
+  // query is fired when the current one settles. Protects the backend from
+  // per-keystroke requests during slow typing.
+  const autocompleteInFlightRef = useRef(false);
+  const autocompletePendingRef = useRef<string | null>(null);
+  // After a commit, suppress any in-flight autocomplete result from
+  // re-opening the dropdown. Cleared as soon as the user starts typing
+  // again so the next session of autocomplete works normally.
+  const suppressAutocompleteRef = useRef(false);
+
+  useEffect(() => {
+    setSearchValue(initialQuery);
+  }, [initialQuery]);
+
+  // True when the visible input no longer matches the last committed
+  // search. While dirty: dropdown is sticky (won't close on outside click),
+  // and the dropdown's footer prompts "Press Enter to search for X".
+  const isDirty = searchValue.length > 0 && searchValue !== committedValue;
+  const isDirtyRef = useRef(isDirty);
+  useEffect(() => {
+    isDirtyRef.current = isDirty;
+  }, [isDirty]);
+
+  const fetchSuggestions = useCallback(async (query: string) => {
+    if (!query || query.length < 2) {
+      setSuggestions([]);
+      setShowSuggestions(false);
+      return;
+    }
+
+    if (autocompleteInFlightRef.current) {
+      autocompletePendingRef.current = query;
+      return;
+    }
+
+    autocompleteInFlightRef.current = true;
+    setIsAutocompleteFetching(true);
+    let current = query;
+
+    try {
+      while (current) {
+        try {
+          const results = await autocomplete(current);
+          if (suppressAutocompleteRef.current) break;
+          // Server can return undefined (e.g. stale-server-action errors in
+          // dev). Guard so `.length` doesn't crash the page.
+          setSuggestions(Array.isArray(results) ? results : []);
+          // Show the dropdown either way — an empty result list renders
+          // a "No suggestions for X" message instead of going silent.
+          setShowSuggestions(true);
+        } catch (err) {
+          console.error('Autocomplete error:', err);
+          if (!suppressAutocompleteRef.current) setSuggestions([]);
+        }
+
+        if (suppressAutocompleteRef.current) break;
+
+        const next = autocompletePendingRef.current;
+        autocompletePendingRef.current = null;
+        if (!next || next === current) break;
+        current = next;
+      }
+    } finally {
+      autocompleteInFlightRef.current = false;
+      setIsAutocompleteFetching(false);
+    }
+  }, []);
+
+  const handleInputChange = (rawValue: string) => {
+    // Strip characters that can never appear in a domain name
+    const value = rawValue.replace(/[^a-zA-Z0-9.-]/g, '');
+    setSearchValue(value);
+    setSelectedIndex(-1);
+    // Resume autocomplete the moment the user starts typing again.
+    suppressAutocompleteRef.current = false;
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    if (!value) {
+      setSuggestions([]);
+      setShowSuggestions(false);
+      setCommittedValue('');
+      setIsAutocompleteFetching(false);
+      onSubmit('');
+      return;
+    }
+
+    if (value.length < 2) {
+      setSuggestions([]);
+      setIsAutocompleteFetching(false);
+      return;
+    }
+
+    // Treat the debounce window itself as "fetching" so the dropdown shows
+    // its loading state immediately instead of going through a brief flash
+    // of stale suggestions or "No suggestions".
+    setIsAutocompleteFetching(true);
+
+    debounceRef.current = setTimeout(() => {
+      fetchSuggestions(value);
+    }, 300);
+  };
+
+  const cancelPendingAutocomplete = () => {
+    suppressAutocompleteRef.current = true;
+    autocompletePendingRef.current = null;
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    setIsAutocompleteFetching(false);
+  };
+
+  const commit = (value: string) => {
+    cancelPendingAutocomplete();
+    setShowSuggestions(false);
+    setCommittedValue(value);
+    onSubmit(value);
+  };
+
+  const handleSuggestionClick = (suggestion: string) => {
+    setSearchValue(suggestion);
+    setSuggestions([]);
+    commit(suggestion);
+    analytics.capture('autocomplete_selected', { domain: suggestion });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (showSuggestions && selectedIndex >= 0) {
+        handleSuggestionClick(suggestions[selectedIndex]);
+      } else if (searchValue) {
+        commit(searchValue);
+      }
+      return;
+    }
+
+    if (!showSuggestions || suggestions.length === 0) return;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setSelectedIndex((prev) =>
+          prev < suggestions.length - 1 ? prev + 1 : prev
+        );
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : -1));
+        break;
+      case 'Escape':
+        setShowSuggestions(false);
+        break;
+    }
+  };
+
+  // Close suggestions when clicking outside — unless the input is dirty,
+  // in which case the dropdown stays visible to keep the "Press Enter to
+  // search for X" hint in view.
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        suggestionsRef.current &&
+        !suggestionsRef.current.contains(e.target as Node) &&
+        inputRef.current &&
+        !inputRef.current.contains(e.target as Node)
+      ) {
+        if (isDirtyRef.current) return;
+        setShowSuggestions(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleClear = () => {
+    setSearchValue('');
+    setSuggestions([]);
+    setShowSuggestions(false);
+    setCommittedValue('');
+    onSubmit('');
+  };
+
+  return (
+    <div className='relative flex w-full items-center gap-2 rounded-lg border border-border px-3 py-2'>
+      <div className='relative min-w-0 flex-1'>
+        <Input
+          ref={inputRef}
+          placeholder={placeholder}
+          value={searchValue}
+          onChange={(e) => handleInputChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onFocus={() => {
+            if (suggestions.length > 0) {
+              setShowSuggestions(true);
+            } else if (searchValue.length >= 2) {
+              setShowSuggestions(true);
+              setIsAutocompleteFetching(true);
+              fetchSuggestions(searchValue);
+            }
+          }}
+          className='h-auto w-full border-0 bg-transparent p-0 text-base leading-tight tracking-tight ring-0 outline-0 focus-visible:ring-0 focus-visible:ring-offset-0'
+        />
+        {searchValue && (
+          <button
+            onClick={handleClear}
+            className='absolute top-1/2 right-0 -translate-y-1/2 hover:text-secondary focus:outline-none'
+            aria-label='Clear search'
+          >
+            <XIcon size={20} weight='bold' color='#606060' />
+          </button>
+        )}
+      </div>
+      <button
+        type='button'
+        onClick={() => searchValue && commit(searchValue)}
+        disabled={!searchValue || isSearchLoading}
+        aria-label={isSearchLoading ? 'Searching' : 'Search'}
+        className='ml-2 flex shrink-0 cursor-pointer items-center rounded-md bg-primary px-3 py-1 text-background transition-opacity hover:opacity-80 disabled:cursor-default disabled:opacity-40'
+      >
+        {isSearchLoading ? (
+          <div
+            className='size-4 animate-spin rounded-full border-2 border-background border-t-transparent'
+            role='status'
+          />
+        ) : (
+          <MagnifyingGlassIcon size={16} weight='bold' />
+        )}
+      </button>
+
+      {(showSuggestions || isDirty) && (
+        <div
+          ref={suggestionsRef}
+          className='absolute top-full left-0 z-50 mt-1 w-full overflow-hidden rounded-lg border border-border bg-foreground shadow-lg'
+        >
+          {isAutocompleteFetching ? (
+            <div className='flex items-center gap-2 px-3 py-2 text-sm text-secondary'>
+              <div
+                className='size-3 animate-spin rounded-full border-2 border-secondary border-t-transparent'
+                role='status'
+              />
+              Looking for domains…
+            </div>
+          ) : suggestions.length > 0 ? (
+            suggestions.map((suggestion, index) => (
+              <button
+                key={suggestion}
+                onClick={() => handleSuggestionClick(suggestion)}
+                className={`hover:bg-muted w-full px-3 py-2 text-left text-sm ${
+                  index === selectedIndex ? 'bg-muted' : ''
+                }`}
+              >
+                {suggestion}
+              </button>
+            ))
+          ) : (
+            <div className='px-3 py-2 text-sm text-secondary'>
+              No suggestions for &quot;{searchValue}&quot;
+            </div>
+          )}
+          {isDirty && (
+            <div className='border-t border-border px-3 py-1.5 text-xs text-secondary'>
+              ↵ Press Enter to search for &quot;{searchValue}&quot;
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/DomainSearchResult.tsx
+++ b/src/components/DomainSearchResult.tsx
@@ -12,6 +12,7 @@ import SelectorDetails from '@/app/search/SelectorDetails';
 interface Props {
   domainQuery: string | undefined;
   filters?: SearchFilters;
+  onLoadingChange?: (loading: boolean) => void;
 }
 
 // Check if a record is expired (last seen > 365 days ago)
@@ -53,53 +54,88 @@ function applyFilters(
   });
 }
 
-export function DomainSearchResults({ domainQuery, filters = {} }: Props) {
+export function DomainSearchResults({
+  domainQuery,
+  filters = {},
+  onLoadingChange,
+}: Props) {
   const [data, setData] = useState<SearchResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
-  // Use refs to prevent race conditions
   const loadingMoreRef = useRef(false);
-  const abortControllerRef = useRef<AbortController | null>(null);
+  // Serialize searches: at most one request in flight at a time. While one
+  // is running, the latest query is stashed in pendingQueryRef and fired
+  // when the current request settles. Server actions can't be aborted, so
+  // this is how we prevent the backend from being hammered by per-keystroke
+  // requests during slow typing.
+  const inFlightRef = useRef(false);
+  const pendingQueryRef = useRef<string | null>(null);
+  const requestIdRef = useRef(0);
 
-  const loadRecords = useCallback(async () => {
-    if (!domainQuery) {
-      setData(null);
+  const runSearchQueue = useCallback(async (initialQuery: string) => {
+    if (inFlightRef.current) {
+      pendingQueryRef.current = initialQuery;
       return;
     }
 
-    // Cancel any in-flight request
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-    abortControllerRef.current = new AbortController();
-
-    setLoading(true);
-    setError(null);
+    inFlightRef.current = true;
+    let current = initialQuery;
 
     try {
-      const response = await searchDomain(domainQuery, null);
-      setData(response);
-    } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') return;
-      setError('Failed to load search results');
-      console.error('Search error:', err);
+      while (current) {
+        const requestId = ++requestIdRef.current;
+        try {
+          const response = await searchDomain(current, null);
+          if (requestId === requestIdRef.current) {
+            // Guard against the server returning undefined (e.g. dev-mode
+            // stale-server-action errors) — keep data null in that case.
+            setData(response ?? null);
+            setError(null);
+          }
+        } catch (err) {
+          if (requestId === requestIdRef.current) {
+            setError('Failed to load search results');
+            console.error('Search error:', err);
+          }
+        }
+
+        const next = pendingQueryRef.current;
+        pendingQueryRef.current = null;
+        if (!next || next === current) break;
+        current = next;
+      }
     } finally {
+      inFlightRef.current = false;
       setLoading(false);
     }
-  }, [domainQuery]);
+  }, []);
+
+  const loadRecords = useCallback(() => {
+    if (!domainQuery) {
+      requestIdRef.current += 1;
+      pendingQueryRef.current = null;
+      setData(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    runSearchQueue(domainQuery);
+  }, [domainQuery, runSearchQueue]);
 
   useEffect(() => {
     loadRecords();
-    // Cleanup on unmount
-    return () => {
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-      }
-    };
   }, [loadRecords]);
+
+  // Mirror the committed-search loading state up to the parent so the
+  // SearchAndFilterSection magnifier button can show a spinner while the
+  // user-initiated search is in flight.
+  useEffect(() => {
+    onLoadingChange?.(loading);
+  }, [loading, onLoadingChange]);
 
   const loadMore = useCallback(async () => {
     // Use ref to prevent multiple concurrent calls

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -410,6 +410,11 @@ export function parseDkimTagListV2(rawHeader: string): Record<string, string> {
 
 export type DomainSelectorPair = { domain: string; selector: string };
 
+// Soft cap on pairs accepted from a single uploaded file. Each pair fires
+// one sequential POST /api/dsp, so even at 5k rows that's ~minutes of
+// processing — anything larger should be split or batched.
+export const MAX_UPLOAD_PAIRS = 5000;
+
 // Parse a TSV file of pre-extracted domain/selector pairs.
 // Format: one row per line, tab-separated, first two columns are
 // `domain` and `selector`. The selector column may include a date suffix
@@ -428,6 +433,11 @@ export function parseTsvPairs(content: string): DomainSelectorPair[] {
     const selector = rawSelector.split(':')[0].trim();
     if (!domain || !selector) continue;
     out.push({ domain, selector });
+    if (out.length >= MAX_UPLOAD_PAIRS) {
+      throw new Error(
+        `TSV file has more than ${MAX_UPLOAD_PAIRS} rows — please split it into smaller files.`
+      );
+    }
   }
   return out;
 }
@@ -459,6 +469,11 @@ export function parseMailboxPairs(content: string): DomainSelectorPair[] {
       if (seen.has(key)) continue;
       seen.add(key);
       out.push({ domain, selector });
+      if (out.length >= MAX_UPLOAD_PAIRS) {
+        throw new Error(
+          `Mailbox produced more than ${MAX_UPLOAD_PAIRS} unique pairs — please split it into smaller files.`
+        );
+      }
     }
   }
   return out;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -407,3 +407,59 @@ export function parseDkimTagListV2(rawHeader: string): Record<string, string> {
       })
   );
 }
+
+export type DomainSelectorPair = { domain: string; selector: string };
+
+// Parse a TSV file of pre-extracted domain/selector pairs.
+// Format: one row per line, tab-separated, first two columns are
+// `domain` and `selector`. The selector column may include a date suffix
+// (e.g. "selector:2024-01-01") — that's the format the old archive's
+// mbox_scraper.py produces; we strip everything after the first `:`.
+export function parseTsvPairs(content: string): DomainSelectorPair[] {
+  const out: DomainSelectorPair[] = [];
+  const lines = content
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+  for (const line of lines) {
+    const [rawDomain, rawSelector] = line.split('\t');
+    if (!rawDomain || !rawSelector) continue;
+    const domain = rawDomain.trim();
+    const selector = rawSelector.split(':')[0].trim();
+    if (!domain || !selector) continue;
+    out.push({ domain, selector });
+  }
+  return out;
+}
+
+// Split an mbox archive into individual raw email messages. Mbox uses
+// "From " (with trailing space) at the start of a line as the message
+// separator; a single .eml file is treated as an mbox with one message.
+export function splitMboxMessages(content: string): string[] {
+  const normalised = content.replace(/\r\n/g, '\n');
+  const parts = normalised.split(/(?:^|\n)From [^\n]*\n/);
+  const messages = parts.map((p) => p.trim()).filter(Boolean);
+  // No mbox separators present at all → treat the whole file as one
+  // message (covers raw .eml uploads).
+  return messages.length > 0 ? messages : [normalised.trim()].filter(Boolean);
+}
+
+// Walk an mbox/.eml file, extract every DKIM-Signature, and return the
+// deduplicated set of {domain, selector} pairs found.
+export function parseMailboxPairs(content: string): DomainSelectorPair[] {
+  const seen = new Set<string>();
+  const out: DomainSelectorPair[] = [];
+  for (const message of splitMboxMessages(content)) {
+    for (const rawHeader of getDkimSigsArray(message)) {
+      const tags = parseDkimTagListV2(rawHeader);
+      const domain = tags['d']?.trim();
+      const selector = tags['s']?.trim();
+      if (!domain || !selector) continue;
+      const key = `${domain}\t${selector}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ domain, selector });
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Addresses all 5 sub-issues under [REG-689](https://linear.app/zk-email/issue/REG-689) (QA feedback round 2):

- **[REG-690](https://linear.app/zk-email/issue/REG-690)** Per-page browser tab titles — root layout uses a \`title.template\`, each route adds a metadata export, home uses \`title.absolute\` (template doesn't apply to its own segment).
- **[REG-691](https://linear.app/zk-email/issue/REG-691)** Contribute page reworked. After confirming intent with Aayush in Slack: three contribution modes in a single side-by-side picker — **Gmail** (OAuth on click), **Mailbox file** (\`.mbox\` / \`.eml\`, we extract the DKIM pairs client-side), and **TSV file** (pre-extracted \`domain\\tselector\` rows as produced by the legacy \`mbox_scraper.py\` / \`pst_scraper.py\` scripts). PST dropped from scope (only viable parser is C/Python \`libpff\`; in-browser isn't feasible and server-side would kill the privacy story). Also: help icons now have working tooltips, "How to get this file?" lifted out of the dropzone as a real \`<a>\` link to the legacy README, \`australianet\` typo fixed to \`example.net\`, hero copy updated. New helpers in \`lib/utils.ts\`: \`parseTsvPairs\`, \`splitMboxMessages\`, \`parseMailboxPairs\`.
- **[REG-692](https://linear.app/zk-email/issue/REG-692)** Reworked search UX. Commit-only (Enter / magnifier / suggestion-pick), char sanitization, request serialization (autocomplete + full search), request-id guards, sticky dropdown with "Looking for domains…" loading state and "Press Enter to search" footer, button-spinner only during committed search, autocomplete cancellation on commit, exact-match pagination fix. Extracted everything into a reusable \`DomainSearchInput\` shared by the homepage and \`/search\`.
- **[REG-693](https://linear.app/zk-email/issue/REG-693)** Activity chart for sub-bucket selectors. Recharts \`<Area>\` can't render a single isolated non-null point, so selectors with first/last seen in the same month had invisible activity. Added a custom dot renderer that only draws for isolated points (multi-month areas unchanged).
- **[REG-694](https://linear.app/zk-email/issue/REG-694)** Surface exact-match domain in autocomplete + search results. Short domains like \`x.com\` were buried under alphabetical substring neighbors (\`101x.com\`, \`1031ex.com\`). Server-side: prepend exact match to autocomplete, fetch up to 10 exact-match records ahead of pagination in \`searchDomain\`. Client-side: \`SelectorDetails\` preserves server order instead of re-sorting alphabetically.

## Post-review polish

After spawning three subagent code reviewers (correctness / UX / security), the following review-driven fixes landed on the same branch:

- **Exact-match pagination dedup on every page.** Previously the \`notIn: exactIds\` filter only ran on page 1, so any exact-domain records that overflowed the priority cap (10) could reappear on later pages. Switched to a permanent NOT clause that excludes the exact-match domain from the alphabetical stream regardless of page (commit \`2db7764\`).
- **\`committedValue\` reset on \`initialQuery\` change.** Browser back/forward navigation that updates \`?q=\` now keeps the dirty-state hint in sync (commit \`5b2df24\`).
- **Upload caps.** Hard cap at 50 MB per file and 5000 pairs per parse, with inline error messages and a "Choose Another File" recovery button when the processing view shows a parse error before any logs (commits \`7784bcd\`, \`5ad28e0\`, \`27eaa82\`).
- **Homepage magnifier spinner wired up.** \`DomainSearchInput.isSearchLoading\` was dead on \`/\` since HomeClient navigates away; now flips true the moment the user submits so the icon spins during the brief load-the-search-page gap (commit \`cf44d16\`).
- **Three-up picker on Contribute.** The previous "big centered Gmail button + OR + two tabs" layout has been collapsed into three side-by-side picker buttons. Gmail kicks off OAuth on click; Mailbox / TSV are toggles that swap the dropzone below. Removes the silent state-swap risk the reviewer flagged (commit \`4c03085\`).

## Test plan
- [x] Browser tab title updates on every route.
- [x] Typing in the search box (any speed) does not fire a search request. Autocomplete is serialized.
- [x] Pressing Enter / clicking the magnifier / picking a suggestion fires exactly one search request.
- [x] Invalid characters are stripped on input.
- [x] Editing input after committing leaves the dropdown sticky with a "Press Enter to search for X" footer.
- [x] Browser back/forward over \`?q=\` does not cause spurious "Press Enter" hints.
- [x] Activity chart renders a green dot for short-lived selectors (e.g. \`amazon.com\` selector \`ezcnblp2xcagjhumwvhrjzsa2sgwawg7\`).
- [x] Searching \`x.com\` shows \`x.com\` at the top of both autocomplete and search results; load-more on a busy domain shows no duplicate tiles.
- [x] Homepage search bar reuses the same \`DomainSearchInput\` component; magnifier shows a spinner during navigation.
- [x] Contribute: three-up picker switches between Gmail / Mailbox / TSV.
- [x] Contribute: \`.mbox\` upload extracts and submits all DKIM pairs (verified against a local Postgres seeded with the synthetic fixture).
- [x] Contribute: \`.eml\` upload extracts and submits DKIM pairs (verified with a real Discord email).
- [x] Contribute: \`.tsv\` upload parses rows and submits each pair (verified locally — fake-domain fixtures correctly rejected by the API's DNS-validation guard).
- [x] Contribute: oversized file shows inline error; >5k-row TSV shows error with "Choose Another File" recovery.
- [x] \`pnpm run build\` passes.

## Deferred to follow-up tickets

- \`EmailUploader\` is ~800 lines; worth splitting (Gmail flow vs. file flow vs. view state machine).
- \`DomainSearchInput\` has 7 useState + 4 refs + 3 effects; candidate for a \`useDomainAutocomplete()\` hook + thin presentational component.
- \`SelectorDetails\` server-order coupling — extract a \`prioritizeExactMatch(domains, query)\` helper so the contract is explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)