### PR TITLE
fix: QA feedback round 3, autocomplete hang and IDN support

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -203,7 +203,7 @@ export async function searchDomain(
   // Exclude the exact-match domain from the alphabetical stream on *every*
   // page (not just the first). Without this, any exact-domain records that
   // overflowed the priority cap on page 1 would reappear as duplicates on
-  // later pages — and totalCount would no longer match what's actually
+  // later pages, and totalCount would no longer match what's actually
   // shown.
   const otherRecords = await prisma.dkimRecord.findMany({
     where: {
@@ -233,7 +233,7 @@ export async function searchDomain(
 
   const searchResults = filteredRecords.map(transformToSearchResult);
   // Pagination cursor tracks the alphabetical (non-exact) stream. Only
-  // signal "load more" when that stream was actually full — otherwise the
+  // signal "load more" when that stream was actually full; otherwise the
   // client wastes a roundtrip fetching an empty next page.
   const nextCursor =
     otherRecords.length === remainingSlots && remainingSlots > 0

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,10 +1,27 @@
 'use server';
+import { domainToASCII, domainToUnicode } from 'node:url';
+
 import {
   type DkimRecord,
   type DomainSelectorPair,
   Prisma,
 } from '@/generated/prisma/client';
 import { prisma } from '@/lib/db';
+
+// DKIM domains are stored in Punycode (xn--…) form in the DB, so any
+// IDN input must be encoded before lookup. ASCII queries pass through
+// unchanged. Falls back to the raw query when domainToASCII rejects the
+// input so the DB call still runs (and returns no rows) rather than
+// throwing on partially typed input.
+function toPunycode(query: string): string {
+  return domainToASCII(query) || query;
+}
+
+// Inverse of toPunycode for display: render "пример.рф" in suggestions
+// and results instead of the raw "xn--e1afmkfd.xn--p1ai" form.
+function toUnicode(domain: string): string {
+  return domainToUnicode(domain) || domain;
+}
 
 // Helper: Build domain search filter with subdomain/variant matching
 function buildDomainFilter(query: string): Prisma.DomainSelectorPairWhereInput {
@@ -34,13 +51,17 @@ const AUTOCOMPLETE_LIMIT = 8;
 export async function autocomplete(query: string): Promise<string[]> {
   if (!query) return [];
 
+  // Punycode-encode the query so IDN inputs ("пример.рф") match the
+  // ASCII form stored in the DB.
+  const asciiQuery = toPunycode(query);
+
   // Always look up the exact match first. Without this, short domains
   // like "x.com" get buried under the top-N alphabetical substring matches
   // ("101x.com", "1031ex.com", ...) and never appear in the dropdown even
   // though the API returns them.
   const exactMatch = await prisma.domainSelectorPair.findFirst({
     where: {
-      domain: { equals: query, mode: Prisma.QueryMode.insensitive },
+      domain: { equals: asciiQuery, mode: Prisma.QueryMode.insensitive },
     },
     select: { domain: true },
   });
@@ -57,23 +78,23 @@ export async function autocomplete(query: string): Promise<string[]> {
   };
 
   // Simple prefix search for short queries
-  if (!query.includes('.') && !query.includes('-')) {
+  if (!asciiQuery.includes('.') && !asciiQuery.includes('-')) {
     const dsps = await prisma.domainSelectorPair.findMany({
       distinct: ['domain'],
       where: {
-        domain: { startsWith: query, mode: Prisma.QueryMode.insensitive },
+        domain: { startsWith: asciiQuery, mode: Prisma.QueryMode.insensitive },
       },
       orderBy: { domain: 'asc' },
       take: remainingSlots,
       select: { domain: true },
     });
-    return prependExact(dsps.map((d) => d.domain));
+    return prependExact(dsps.map((d) => d.domain)).map(toUnicode);
   }
 
   // Multi-strategy search for queries with dots/dashes
   const dsps = await prisma.domainSelectorPair.findMany({
     distinct: ['domain'],
-    where: buildDomainFilter(query),
+    where: buildDomainFilter(asciiQuery),
     orderBy: { domain: 'asc' },
     take: remainingSlots,
     select: { domain: true },
@@ -83,14 +104,14 @@ export async function autocomplete(query: string): Promise<string[]> {
   const sorted = dsps
     .map((d) => d.domain)
     .sort((a, b) => {
-      const aStarts = a.toLowerCase().startsWith(query.toLowerCase());
-      const bStarts = b.toLowerCase().startsWith(query.toLowerCase());
+      const aStarts = a.toLowerCase().startsWith(asciiQuery.toLowerCase());
+      const bStarts = b.toLowerCase().startsWith(asciiQuery.toLowerCase());
       if (aStarts && !bStarts) return -1;
       if (!aStarts && bStarts) return 1;
       return a.localeCompare(b);
     });
 
-  return prependExact(sorted);
+  return prependExact(sorted).map(toUnicode);
 }
 
 export type RecordWithSelector = DkimRecord & {
@@ -125,7 +146,7 @@ export type SearchFilters = {
 function transformToSearchResult(record: RecordWithSelector): SearchResult {
   return {
     id: record.id,
-    domain: record.domainSelectorPair.domain,
+    domain: toUnicode(record.domainSelectorPair.domain),
     selector: record.domainSelectorPair.selector,
     firstActive: record.firstSeenAt.toISOString(),
     lastActive:
@@ -149,7 +170,11 @@ export async function searchDomain(
     return { searchResults: [], nextCursor: null, totalCount: 0 };
   }
 
-  const domainFilter = buildDomainFilter(domainQuery);
+  // Encode IDN inputs to Punycode before any DB lookup. ASCII queries
+  // pass through unchanged.
+  const asciiQuery = toPunycode(domainQuery);
+
+  const domainFilter = buildDomainFilter(asciiQuery);
 
   // On the first page, surface up to EXACT_MATCH_PRIORITY_LIMIT records
   // for the exact-match domain. Without this, short domains like "x.com"
@@ -162,7 +187,7 @@ export async function searchDomain(
           where: {
             domainSelectorPair: {
               domain: {
-                equals: domainQuery,
+                equals: asciiQuery,
                 mode: Prisma.QueryMode.insensitive,
               },
             },
@@ -186,7 +211,7 @@ export async function searchDomain(
         ...domainFilter,
         NOT: {
           domain: {
-            equals: domainQuery,
+            equals: asciiQuery,
             mode: Prisma.QueryMode.insensitive,
           },
         },

--- a/src/components/DomainSearchInput.tsx
+++ b/src/components/DomainSearchInput.tsx
@@ -9,7 +9,9 @@ import { analytics } from '@/lib/analytics';
 
 // Hard cap on each autocomplete request so a hung server action can't
 // permanently stall the in-flight ref (and therefore the dropdown).
-const AUTOCOMPLETE_TIMEOUT_MS = 8000;
+// Generous so that genuinely slow queries don't trip it — this is a hang
+// detector, not a tight latency bound.
+const AUTOCOMPLETE_TIMEOUT_MS = 20000;
 
 type DomainSearchInputProps = {
   initialQuery?: string;
@@ -33,6 +35,10 @@ export function DomainSearchInput({
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [isAutocompleteFetching, setIsAutocompleteFetching] = useState(false);
+  // Distinguishes "server returned no matches" (show "No suggestions for X")
+  // from "request failed/timed out" (show a softer message that doesn't
+  // imply zero results exist — pressing Enter may still find something).
+  const [autocompleteFailed, setAutocompleteFailed] = useState(false);
   // Tracks the value most recently committed so the "Press Enter to search"
   // hint only shows when the input differs.
   const [committedValue, setCommittedValue] = useState(initialQuery);
@@ -83,6 +89,7 @@ export function DomainSearchInput({
 
     autocompleteInFlightRef.current = true;
     setIsAutocompleteFetching(true);
+    setAutocompleteFailed(false);
     let current = query;
 
     try {
@@ -101,12 +108,16 @@ export function DomainSearchInput({
           // Server can return undefined (e.g. stale-server-action errors in
           // dev). Guard so `.length` doesn't crash the page.
           setSuggestions(Array.isArray(results) ? results : []);
+          setAutocompleteFailed(false);
           // Show the dropdown either way — an empty result list renders
           // a "No suggestions for X" message instead of going silent.
           setShowSuggestions(true);
         } catch (err) {
           console.error('Autocomplete error:', err);
-          if (!suppressAutocompleteRef.current) setSuggestions([]);
+          if (!suppressAutocompleteRef.current) {
+            setSuggestions([]);
+            setAutocompleteFailed(true);
+          }
         }
 
         if (suppressAutocompleteRef.current) break;
@@ -123,12 +134,19 @@ export function DomainSearchInput({
   }, []);
 
   const handleInputChange = (rawValue: string) => {
-    // Strip characters that can never appear in a domain name
-    const value = rawValue.replace(/[^a-zA-Z0-9.-]/g, '');
+    // Allow ASCII alphanumerics, dots, dashes, and any Unicode letter,
+    // number, or combining mark so IDN domains can be typed in any script.
+    // Marks (\p{M}) cover Thai vowel signs (เกาะกูด), Vietnamese diacritics
+    // (việt), Hindi vowels (हिन्दी), etc. — stripping them would silently
+    // mangle valid input. Punycode conversion happens server-side.
+    const value = rawValue.replace(/[^\p{L}\p{N}\p{M}.-]/gu, '');
     setSearchValue(value);
     setSelectedIndex(-1);
     // Resume autocomplete the moment the user starts typing again.
     suppressAutocompleteRef.current = false;
+    // Clear any stale "couldn't load" message — the next fetch decides the
+    // new state.
+    setAutocompleteFailed(false);
 
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
@@ -313,6 +331,10 @@ export function DomainSearchInput({
                 {suggestion}
               </button>
             ))
+          ) : autocompleteFailed ? (
+            <div className='px-3 py-2 text-sm text-secondary'>
+              Couldn&apos;t load suggestions — press Enter to search
+            </div>
           ) : (
             <div className='px-3 py-2 text-sm text-secondary'>
               No suggestions for &quot;{searchValue}&quot;

--- a/src/components/DomainSearchInput.tsx
+++ b/src/components/DomainSearchInput.tsx
@@ -9,7 +9,7 @@ import { analytics } from '@/lib/analytics';
 
 // Hard cap on each autocomplete request so a hung server action can't
 // permanently stall the in-flight ref (and therefore the dropdown).
-// Generous so that genuinely slow queries don't trip it — this is a hang
+// Generous so that genuinely slow queries don't trip it, since this is a hang
 // detector, not a tight latency bound.
 const AUTOCOMPLETE_TIMEOUT_MS = 20000;
 
@@ -37,7 +37,7 @@ export function DomainSearchInput({
   const [isAutocompleteFetching, setIsAutocompleteFetching] = useState(false);
   // Distinguishes "server returned no matches" (show "No suggestions for X")
   // from "request failed/timed out" (show a softer message that doesn't
-  // imply zero results exist — pressing Enter may still find something).
+  // imply zero results exist; pressing Enter may still find something).
   const [autocompleteFailed, setAutocompleteFailed] = useState(false);
   // Tracks the value most recently committed so the "Press Enter to search"
   // hint only shows when the input differs.
@@ -109,7 +109,7 @@ export function DomainSearchInput({
           // dev). Guard so `.length` doesn't crash the page.
           setSuggestions(Array.isArray(results) ? results : []);
           setAutocompleteFailed(false);
-          // Show the dropdown either way — an empty result list renders
+          // Show the dropdown either way: an empty result list renders
           // a "No suggestions for X" message instead of going silent.
           setShowSuggestions(true);
         } catch (err) {
@@ -137,14 +137,14 @@ export function DomainSearchInput({
     // Allow ASCII alphanumerics, dots, dashes, and any Unicode letter,
     // number, or combining mark so IDN domains can be typed in any script.
     // Marks (\p{M}) cover Thai vowel signs (เกาะกูด), Vietnamese diacritics
-    // (việt), Hindi vowels (हिन्दी), etc. — stripping them would silently
+    // (việt), Hindi vowels (हिन्दी), etc., since stripping them would silently
     // mangle valid input. Punycode conversion happens server-side.
     const value = rawValue.replace(/[^\p{L}\p{N}\p{M}.-]/gu, '');
     setSearchValue(value);
     setSelectedIndex(-1);
     // Resume autocomplete the moment the user starts typing again.
     suppressAutocompleteRef.current = false;
-    // Clear any stale "couldn't load" message — the next fetch decides the
+    // Clear any stale "couldn't load" message; the next fetch decides the
     // new state.
     setAutocompleteFailed(false);
 
@@ -231,7 +231,7 @@ export function DomainSearchInput({
     }
   };
 
-  // Close suggestions when clicking outside — unless the input is dirty,
+  // Close suggestions when clicking outside, unless the input is dirty,
   // in which case the dropdown stays visible to keep the "Press Enter to
   // search for X" hint in view.
   useEffect(() => {
@@ -333,7 +333,7 @@ export function DomainSearchInput({
             ))
           ) : autocompleteFailed ? (
             <div className='px-3 py-2 text-sm text-secondary'>
-              Couldn&apos;t load suggestions — press Enter to search
+              Couldn&apos;t load suggestions, press Enter to search
             </div>
           ) : (
             <div className='px-3 py-2 text-sm text-secondary'>

--- a/src/components/DomainSearchInput.tsx
+++ b/src/components/DomainSearchInput.tsx
@@ -7,6 +7,10 @@ import { autocomplete } from '@/app/actions';
 import { Input } from '@/components/ui/input';
 import { analytics } from '@/lib/analytics';
 
+// Hard cap on each autocomplete request so a hung server action can't
+// permanently stall the in-flight ref (and therefore the dropdown).
+const AUTOCOMPLETE_TIMEOUT_MS = 8000;
+
 type DomainSearchInputProps = {
   initialQuery?: string;
   // Fired when the user commits a search (Enter, magnifier-click, picking
@@ -84,7 +88,15 @@ export function DomainSearchInput({
     try {
       while (current) {
         try {
-          const results = await autocomplete(current);
+          const results = await Promise.race([
+            autocomplete(current),
+            new Promise<string[]>((_, reject) =>
+              setTimeout(
+                () => reject(new Error('autocomplete timed out')),
+                AUTOCOMPLETE_TIMEOUT_MS
+              )
+            ),
+          ]);
           if (suppressAutocompleteRef.current) break;
           // Server can return undefined (e.g. stale-server-action errors in
           // dev). Guard so `.length` doesn't crash the page.


### PR DESCRIPTION
## Summary

Round 3 QA fixes for the Archive ([REG-695](https://linear.app/zk-email/issue/REG-695)):

- **[REG-696](https://linear.app/zk-email/issue/REG-696)**: wrap the autocomplete server action in a 20s `Promise.race` timeout so a hung request can't permanently brick the in-flight ref and freeze the dropdown. On timeout the dropdown shows a clear "Couldn't load suggestions, press Enter to search" message instead of the misleading "No suggestions for X".
- **[REG-698](https://linear.app/zk-email/issue/REG-698)**: support IDN domains in search. Loosens the input filter to allow Unicode letters, numbers, and combining marks (Thai vowel signs, Vietnamese diacritics, Hindi vowels, etc., previously stripped, silently mangling input). Server actions Punycode-encode at the boundary and decode results back to Unicode for display.

Note: the server-side slowness investigation (REG-697) is being closed separately with a comprehensive findings comment and a new performance-optimization parent issue (REG-699) with implementation sub-tickets.

## Test plan

- [x] REG-696: open `/`, throttle the autocomplete server action (DevTools, block request), type a query. Dropdown clears within ~20s, then "Couldn't load suggestions, press Enter to search" appears. New keystrokes fire fresh requests (in-flight ref not bricked). [QA verified through round 3 sign-off]
- [x] REG-698: paste `เกาะกูด.net` (Thai), `予算管理.biz` (Japanese), or `пример.рф` (Cyrillic) into the search box. Characters are preserved (not stripped). Search returns the right record, displayed in Unicode form. [QA verified through round 3 sign-off; backed by the IDN backfill on `archive_new` showing 215 rows where `domainUnicode <> domain` — all surfaced correctly]
- [x] Sanity: existing ASCII searches (`gmail.com`, `ethereum.org`) behave exactly as before. [verified continuously in production]