### PR TITLE
fix: QA feedback round 4 (REG-708)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "prettier": "prettier --write --cache .",
     "prettier:check": "prettier --check .",
     "start": "next start",
-    "jwks:update": "tsx scripts/update-jwks.ts"
+    "jwks:update": "tsx scripts/update-jwks.ts",
+    "backfill:domain-unicode": "tsx scripts/backfill-domain-unicode.ts"
   },
   "dependencies": {
     "@google-cloud/tasks": "5.1.0",

--- a/prisma/migrations/20260525120000_add_domain_unicode_column/migration.sql
+++ b/prisma/migrations/20260525120000_add_domain_unicode_column/migration.sql
@@ -1,0 +1,29 @@
+-- Adds a denormalized Unicode form of `domain` to DomainSelectorPair so
+-- substring searches in non-Latin scripts (Cyrillic, Thai, Japanese, etc.)
+-- can match partial queries. Punycode encoding is not prefix-preserving;
+-- without a separate column, searching for "прайм" can never find the
+-- row stored as `xn--19-6kc0bpph.xn--p1ai`. See REG-711.
+--
+-- For ASCII domains: domainUnicode equals domain. For IDN domains: it
+-- holds the decoded Unicode label (e.g. `прайм19.рф`). The initial UPDATE
+-- below seeds every row with `domain`; a separate Node.js backfill
+-- script (`scripts/backfill-domain-unicode.ts`) follows up to decode IDN
+-- rows. The application's write path is also updated to populate the
+-- column correctly on new inserts.
+--
+-- The index is added without CONCURRENTLY because Prisma migrations run
+-- inside a transaction. For prod we apply CONCURRENTLY manually
+-- out-of-band (same pattern used for the original pg_trgm index in
+-- REG-701); the `IF NOT EXISTS` clause makes this file a no-op in that
+-- case. On fresh setups the regular CREATE INDEX runs and briefly locks
+-- the table — fine when there is no traffic.
+
+ALTER TABLE "DomainSelectorPair"
+  ADD COLUMN IF NOT EXISTS "domainUnicode" TEXT NOT NULL DEFAULT '';
+
+UPDATE "DomainSelectorPair"
+  SET "domainUnicode" = domain
+  WHERE "domainUnicode" = '';
+
+CREATE INDEX IF NOT EXISTS idx_domain_selector_pair_domain_unicode_trgm
+  ON "DomainSelectorPair" USING gin ("domainUnicode" gin_trgm_ops);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,18 +26,28 @@ model DkimRecord {
 model DomainSelectorPair {
   id               Int          @id @default(autoincrement())
   domain           String
+  // Unicode-decoded form of `domain`. For ASCII domains equals `domain`.
+  // For IDN domains (xn--…) holds the decoded label (e.g. "прайм19.рф").
+  // Maintained so substring search can match partial Unicode queries
+  // like "прайм"; Punycode encoding is not prefix-preserving so the
+  // encoded form alone can't be substring-searched in Cyrillic / Thai /
+  // etc. See REG-711.
+  domainUnicode    String       @default("")
   lastRecordUpdate DateTime?
   selector         String
   sourceIdentifier String
   records          DkimRecord[]
 
   @@index([domain, selector])
-  // Also declared out-of-band:
-  //   idx_domain_selector_pair_domain_trgm — GIN trigram index on (domain)
-  //   for fast ILIKE substring search. See
-  //   prisma/migrations/20260521151000_add_pg_trgm_index/migration.sql.
-  //   Not expressible in schema.prisma without enabling the
-  //   postgresqlExtensions preview feature.
+  // Also declared out-of-band (Prisma can't express gin_trgm_ops without
+  // the postgresqlExtensions preview feature):
+  //   idx_domain_selector_pair_domain_trgm
+  //     GIN trigram index on (domain). See
+  //     prisma/migrations/20260521151000_add_pg_trgm_index/migration.sql.
+  //   idx_domain_selector_pair_domain_unicode_trgm
+  //     GIN trigram index on (domainUnicode) for partial-IDN substring
+  //     search. See
+  //     prisma/migrations/20260525120000_add_domain_unicode_column/migration.sql.
 }
 
 model EmailPairGcdResult {

--- a/scripts/backfill-domain-unicode.ts
+++ b/scripts/backfill-domain-unicode.ts
@@ -1,0 +1,93 @@
+// One-off backfill for the `domainUnicode` column on DomainSelectorPair.
+//
+// Context: the 20260525120000_add_domain_unicode_column migration adds
+// the column and seeds every row with `domainUnicode = domain`. That's
+// correct for ASCII domains. For IDN domains (`xn--...`) it leaves the
+// Punycode form in place, which means partial-IDN substring search
+// (e.g. `прайм` finding `прайм19.рф`) still doesn't work for those
+// rows. This script decodes each IDN row's Punycode form to its
+// Unicode label and updates the column.
+//
+// Idempotent: re-running it is harmless. Only updates rows where
+// `domain` looks like Punycode (`xn--*`) and `domainUnicode` is still
+// the Punycode form (i.e. hasn't been decoded yet).
+//
+// Usage:
+//   pnpm tsx scripts/backfill-domain-unicode.ts
+//
+// Or via package.json script if added.
+
+import 'dotenv/config';
+
+import { domainToUnicode } from 'node:url';
+
+import { PrismaPg } from '@prisma/adapter-pg';
+import { Pool } from 'pg';
+
+import { PrismaClient } from '../src/generated/prisma/client';
+
+async function main() {
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    console.log(
+      `[${new Date().toISOString()}] starting domainUnicode backfill`
+    );
+
+    // Distinct IDN domains that still have their Punycode form sitting
+    // in domainUnicode (i.e. haven't been decoded yet).
+    const idnDomains = await prisma.domainSelectorPair.findMany({
+      where: {
+        domain: { startsWith: 'xn--', mode: 'insensitive' },
+      },
+      select: { domain: true, domainUnicode: true },
+      distinct: ['domain'],
+    });
+
+    console.log(`Found ${idnDomains.length} distinct IDN domains.`);
+
+    let domainsUpdated = 0;
+    let rowsUpdated = 0;
+    let skippedAlreadyDecoded = 0;
+    let skippedDecoderFailed = 0;
+
+    for (const row of idnDomains) {
+      const decoded = domainToUnicode(row.domain) || row.domain;
+      if (decoded === row.domain) {
+        // Decoder returned the input unchanged. Means it's not a valid
+        // Punycode label (unlikely but possible for hand-crafted data).
+        // Skip; the row already has `domainUnicode = domain` which is
+        // the best fallback we can offer.
+        skippedDecoderFailed++;
+        continue;
+      }
+
+      if (row.domainUnicode === decoded) {
+        skippedAlreadyDecoded++;
+        continue;
+      }
+
+      const result = await prisma.domainSelectorPair.updateMany({
+        where: { domain: row.domain },
+        data: { domainUnicode: decoded },
+      });
+      domainsUpdated++;
+      rowsUpdated += result.count;
+    }
+
+    console.log(
+      `[${new Date().toISOString()}] backfill complete: ${domainsUpdated} domains, ${rowsUpdated} rows updated; ${skippedAlreadyDecoded} already-decoded; ${skippedDecoderFailed} decoder-failed.`
+    );
+    process.exit(0);
+  } finally {
+    await prisma.$disconnect();
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('Backfill threw:', err);
+  process.exit(1);
+});

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -47,76 +47,95 @@ function toUnicode(domain: string): string {
   return domainToUnicode(domain) || domain;
 }
 
-// Decide whether a matched domain should be shown to the user and in
-// which form (Unicode vs Punycode). Three cases:
-//
-//   1. Query appears in the human-readable Unicode form. Always show,
-//      render in Unicode. The normal case for ASCII and full-IDN
-//      queries.
-//
-//   2. Query only matches the Punycode encoding artifacts (e.g. ASCII
-//      query `--` finds IDN domains whose stored `xn--…` prefix
-//      contains `--`). Show only when the user looks like they
-//      explicitly typed Punycode (their query contains "xn-").
-//      Otherwise hide the row entirely; showing `xn--0kqx72g9fffb.biz`
-//      to someone who searched for `--` is just confusing.
-//
-//   3. The query is in neither form (shouldn't normally happen given
-//      our substring filter). Hide.
-function decideDomainDisplay(
-  punycodeDomain: string,
-  query: string
-): { display: string; show: boolean } {
-  const queryLower = query.toLowerCase();
-  const unicode = toUnicode(punycodeDomain);
-
-  if (unicode.toLowerCase().includes(queryLower)) {
-    return { display: unicode, show: true };
-  }
-
-  if (
-    queryLower.includes('xn-') &&
-    punycodeDomain.toLowerCase().includes(queryLower)
-  ) {
-    return { display: punycodeDomain, show: true };
-  }
-
-  return { display: punycodeDomain, show: false };
+// True when the user's query looks like they're searching the
+// Punycode encoded form (contains the standard `xn-` token). Used to
+// pick whether to query and display in Punycode or Unicode.
+function isPunycodeQuery(query: string): boolean {
+  return query.toLowerCase().includes('xn-');
 }
 
-// Helper: Build domain search filter with subdomain/variant matching.
-// Searches both:
-//   - `domain` (Punycode form) with asciiQuery: catches ASCII matches
-//     and full-IDN-domain matches (the IDN form was Punycode-encoded
-//     to asciiQuery on the way in).
-//   - `domainUnicode` (Unicode form) with the original unicodeQuery:
-//     catches partial-IDN matches like `прайм` finding `прайм19.рф`,
-//     which can't be substring-matched against the Punycode form
-//     (Punycode encoding is not prefix-preserving). See REG-711.
-// The dot<->dash variants only apply to the Punycode column; Unicode
-// labels don't have the same dash/dot substitution pattern.
+// Pick the display form for a matched domain. If the user looks like
+// they typed Punycode (`xn-`), keep the Punycode form they searched
+// for. Otherwise render the human-readable Unicode form (which equals
+// the domain itself for ASCII rows).
+//
+// The DB query path already filters to rows that match in the same
+// column we render here (see buildDomainFilter and the autocomplete
+// prefix branch), so there's no "hide this row" case here anymore;
+// every row returned from the DB has a sensible display form.
+function pickDomainDisplay(punycodeDomain: string, query: string): string {
+  return isPunycodeQuery(query) ? punycodeDomain : toUnicode(punycodeDomain);
+}
+
+// Build the domain search filter. We pick one column to search based
+// on the user's query intent so the DB doesn't return rows we'd just
+// drop client-side:
+//
+//   - Query looks like Punycode (contains "xn-"): search `domain`.
+//     Catches `xn--...` IDN rows and any ASCII domains whose name
+//     contains `xn-` (e.g. `txn-mg.kiwi.com`). Variants apply (some
+//     domains substitute `-` for `.`).
+//
+//   - Otherwise (the normal case: ASCII or human-readable IDN
+//     queries): search `domainUnicode`. For ASCII rows this equals
+//     `domain`, so plain ASCII searches like `gmail` still hit. For
+//     IDN rows this is the decoded label (e.g. `прайм19.рф`), which
+//     enables partial Unicode substring matches (`прайм`). Variants
+//     apply here too; for queries with no `.` or `-` they reduce to
+//     identical clauses and Postgres handles dedupe.
+//
+// Either way we still get GIN trigram acceleration (each column has
+// its own trigram index, see REG-701 / REG-711).
 function buildDomainFilter(
   asciiQuery: string,
   unicodeQuery: string
 ): Prisma.DomainSelectorPairWhereInput {
-  const modifiedQuery = asciiQuery.replace(/\./g, '-');
-  const modifiedQuery2 = asciiQuery.replace(/-/g, '.');
+  if (isPunycodeQuery(unicodeQuery)) {
+    const modifiedQuery = asciiQuery.replace(/\./g, '-');
+    const modifiedQuery2 = asciiQuery.replace(/-/g, '.');
+    return {
+      OR: [
+        {
+          domain: {
+            contains: asciiQuery,
+            mode: Prisma.QueryMode.insensitive,
+          },
+        },
+        {
+          domain: {
+            contains: modifiedQuery,
+            mode: Prisma.QueryMode.insensitive,
+          },
+        },
+        {
+          domain: {
+            contains: modifiedQuery2,
+            mode: Prisma.QueryMode.insensitive,
+          },
+        },
+      ],
+    };
+  }
 
+  const modifiedQuery = unicodeQuery.replace(/\./g, '-');
+  const modifiedQuery2 = unicodeQuery.replace(/-/g, '.');
   return {
     OR: [
-      { domain: { contains: asciiQuery, mode: Prisma.QueryMode.insensitive } },
       {
-        domain: { contains: modifiedQuery, mode: Prisma.QueryMode.insensitive },
-      },
-      {
-        domain: {
-          contains: modifiedQuery2,
+        domainUnicode: {
+          contains: unicodeQuery,
           mode: Prisma.QueryMode.insensitive,
         },
       },
       {
         domainUnicode: {
-          contains: unicodeQuery,
+          contains: modifiedQuery,
+          mode: Prisma.QueryMode.insensitive,
+        },
+      },
+      {
+        domainUnicode: {
+          contains: modifiedQuery2,
           mode: Prisma.QueryMode.insensitive,
         },
       },
@@ -169,38 +188,33 @@ export async function autocomplete(query: string): Promise<string[]> {
     return [exactMatch.domain, ...deduped].slice(0, AUTOCOMPLETE_LIMIT);
   };
 
-  // Pick + filter helper so a list of raw Punycode domains becomes the
-  // user-facing display list, dropping rows the user shouldn't see
-  // (see decideDomainDisplay).
+  // Pick the display form (Unicode or Punycode) per result; the SQL
+  // path already filtered to rows that match the chosen column, so
+  // every row coming back has a sensible display form.
   const toDisplay = (domains: string[]): string[] =>
-    domains
-      .map((d) => decideDomainDisplay(d, query))
-      .filter((r) => r.show)
-      .map((r) => r.display);
+    domains.map((d) => pickDomainDisplay(d, query));
 
   let result: string[];
   if (!asciiQuery.includes('.') && !asciiQuery.includes('-')) {
-    // Simple prefix search for short queries. Search both domain (for
-    // ASCII and Punycode-form queries) and domainUnicode (for partial
-    // IDN queries like "прайм").
+    // Simple prefix search for short queries. Pick the column to
+    // search based on whether the user's query looks like Punycode
+    // (`xn-`); see buildDomainFilter for the rationale.
+    const prefixWhere = isPunycodeQuery(query)
+      ? {
+          domain: {
+            startsWith: asciiQuery,
+            mode: Prisma.QueryMode.insensitive,
+          },
+        }
+      : {
+          domainUnicode: {
+            startsWith: query,
+            mode: Prisma.QueryMode.insensitive,
+          },
+        };
     const dsps = await prisma.domainSelectorPair.findMany({
       distinct: ['domain'],
-      where: {
-        OR: [
-          {
-            domain: {
-              startsWith: asciiQuery,
-              mode: Prisma.QueryMode.insensitive,
-            },
-          },
-          {
-            domainUnicode: {
-              startsWith: query,
-              mode: Prisma.QueryMode.insensitive,
-            },
-          },
-        ],
-      },
+      where: prefixWhere,
       orderBy: { domain: 'asc' },
       take: remainingSlots,
       select: { domain: true },
@@ -264,24 +278,16 @@ export type SearchFilters = {
   toDate?: string;
 };
 
-// Transform DB record to frontend format. `query` is the user's original
-// (possibly Unicode) input; it drives whether we display each domain in
-// Unicode or Punycode form. See decideDomainDisplay for the rule.
-//
-// Assumes the caller has already filtered out records where
-// decideDomainDisplay would return show=false (e.g. via a prior pass).
-// Falls back to the Unicode form defensively if the decision somehow
-// disagrees, to avoid a `domain: ''` ending up in the UI.
+// Transform DB record to frontend format. `query` is the user's
+// original (possibly Unicode) input; it drives whether we display
+// each domain in Unicode or Punycode form. See pickDomainDisplay.
 function transformToSearchResult(
   record: RecordWithSelector,
   query: string
 ): SearchResult {
-  const decision = decideDomainDisplay(record.domainSelectorPair.domain, query);
   return {
     id: record.id,
-    domain: decision.show
-      ? decision.display
-      : toUnicode(record.domainSelectorPair.domain),
+    domain: pickDomainDisplay(record.domainSelectorPair.domain, query),
     selector: record.domainSelectorPair.selector,
     firstActive: record.firstSeenAt.toISOString(),
     lastActive:
@@ -392,17 +398,7 @@ export async function searchDomain(
     return match && match[1] && match[1].trim().length > 0;
   });
 
-  // Filter out rows where the user's query only matched Punycode
-  // encoding artifacts (e.g. ASCII `--` finding `xn--…` IDN domains).
-  // The user typed something that has no clear human-readable match in
-  // those rows, so showing them would be confusing. Power users who
-  // want Punycode results explicitly type "xn-" somewhere in the
-  // query; see decideDomainDisplay.
-  const visibleRecords = filteredRecords.filter(
-    (r) => decideDomainDisplay(r.domainSelectorPair.domain, domainQuery).show
-  );
-
-  const searchResults = visibleRecords.map((r) =>
+  const searchResults = filteredRecords.map((r) =>
     transformToSearchResult(r, domainQuery)
   );
 

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -47,6 +47,23 @@ function toUnicode(domain: string): string {
   return domainToUnicode(domain) || domain;
 }
 
+// Pick the display form for a domain so the user can see WHY it matched
+// their query. ASCII queries like `--` find IDN domains via their `xn--`
+// Punycode prefix; without this helper we would display those matches in
+// Unicode form (which doesn't contain `--`) and the user would think the
+// result was unrelated. Conversely, when the user typed a Unicode IDN
+// query, we want to keep the nicer Unicode display.
+//
+// Rule: if the human-readable Unicode form contains the query, show
+// Unicode. Otherwise show the raw Punycode (which is what actually
+// matched).
+function pickDomainDisplay(punycodeDomain: string, query: string): string {
+  const unicode = toUnicode(punycodeDomain);
+  return unicode.toLowerCase().includes(query.toLowerCase())
+    ? unicode
+    : punycodeDomain;
+}
+
 // Helper: Build domain search filter with subdomain/variant matching
 function buildDomainFilter(query: string): Prisma.DomainSelectorPairWhereInput {
   const modifiedQuery = query.replace(/\./g, '-');
@@ -79,10 +96,13 @@ export async function autocomplete(query: string): Promise<string[]> {
   // ASCII form stored in the DB.
   const asciiQuery = toPunycode(query);
 
-  // Cache hit fast-path. Cached value is the final Unicode-rendered
-  // suggestion list, so a hit obviates both the DB call and the
-  // post-processing.
-  const cached = autocompleteCache.get(asciiQuery);
+  // Cache hit fast-path. The cache key includes the original query (not
+  // just the Punycode-encoded form) because the chosen display form per
+  // result depends on which form matched: e.g. an ASCII `--` query and
+  // a Cyrillic `пример` query may resolve to overlapping Punycode hits
+  // but should render differently to the user.
+  const cacheKey = `${asciiQuery}|${query.toLowerCase()}`;
+  const cached = autocompleteCache.get(cacheKey);
   if (cached !== undefined) return cached;
 
   // Always look up the exact match first. Without this, short domains
@@ -122,7 +142,9 @@ export async function autocomplete(query: string): Promise<string[]> {
       take: remainingSlots,
       select: { domain: true },
     });
-    result = prependExact(dsps.map((d) => d.domain)).map(toUnicode);
+    result = prependExact(dsps.map((d) => d.domain)).map((d) =>
+      pickDomainDisplay(d, query)
+    );
   } else {
     // Multi-strategy search for queries with dots/dashes
     const dsps = await prisma.domainSelectorPair.findMany({
@@ -144,10 +166,10 @@ export async function autocomplete(query: string): Promise<string[]> {
         return a.localeCompare(b);
       });
 
-    result = prependExact(sorted).map(toUnicode);
+    result = prependExact(sorted).map((d) => pickDomainDisplay(d, query));
   }
 
-  autocompleteCache.set(asciiQuery, result);
+  autocompleteCache.set(cacheKey, result);
   return result;
 }
 
@@ -181,11 +203,16 @@ export type SearchFilters = {
   toDate?: string;
 };
 
-// Transform DB record to frontend format
-function transformToSearchResult(record: RecordWithSelector): SearchResult {
+// Transform DB record to frontend format. `query` is the user's original
+// (possibly Unicode) input; it drives whether we display each domain in
+// Unicode or Punycode form. See pickDomainDisplay for the rule.
+function transformToSearchResult(
+  record: RecordWithSelector,
+  query: string
+): SearchResult {
   return {
     id: record.id,
-    domain: toUnicode(record.domainSelectorPair.domain),
+    domain: pickDomainDisplay(record.domainSelectorPair.domain, query),
     selector: record.domainSelectorPair.selector,
     firstActive: record.firstSeenAt.toISOString(),
     lastActive:
@@ -294,7 +321,9 @@ export async function searchDomain(
     return match && match[1] && match[1].trim().length > 0;
   });
 
-  const searchResults = filteredRecords.map(transformToSearchResult);
+  const searchResults = filteredRecords.map((r) =>
+    transformToSearchResult(r, domainQuery)
+  );
 
   // Signal "load more" only when otherRecords filled the page; otherwise
   // the client wastes a roundtrip fetching an empty next page.

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -84,20 +84,39 @@ function decideDomainDisplay(
   return { display: punycodeDomain, show: false };
 }
 
-// Helper: Build domain search filter with subdomain/variant matching
-function buildDomainFilter(query: string): Prisma.DomainSelectorPairWhereInput {
-  const modifiedQuery = query.replace(/\./g, '-');
-  const modifiedQuery2 = query.replace(/-/g, '.');
+// Helper: Build domain search filter with subdomain/variant matching.
+// Searches both:
+//   - `domain` (Punycode form) with asciiQuery: catches ASCII matches
+//     and full-IDN-domain matches (the IDN form was Punycode-encoded
+//     to asciiQuery on the way in).
+//   - `domainUnicode` (Unicode form) with the original unicodeQuery:
+//     catches partial-IDN matches like `прайм` finding `прайм19.рф`,
+//     which can't be substring-matched against the Punycode form
+//     (Punycode encoding is not prefix-preserving). See REG-711.
+// The dot<->dash variants only apply to the Punycode column; Unicode
+// labels don't have the same dash/dot substitution pattern.
+function buildDomainFilter(
+  asciiQuery: string,
+  unicodeQuery: string
+): Prisma.DomainSelectorPairWhereInput {
+  const modifiedQuery = asciiQuery.replace(/\./g, '-');
+  const modifiedQuery2 = asciiQuery.replace(/-/g, '.');
 
   return {
     OR: [
-      { domain: { contains: query, mode: Prisma.QueryMode.insensitive } },
+      { domain: { contains: asciiQuery, mode: Prisma.QueryMode.insensitive } },
       {
         domain: { contains: modifiedQuery, mode: Prisma.QueryMode.insensitive },
       },
       {
         domain: {
           contains: modifiedQuery2,
+          mode: Prisma.QueryMode.insensitive,
+        },
+      },
+      {
+        domainUnicode: {
+          contains: unicodeQuery,
           mode: Prisma.QueryMode.insensitive,
         },
       },
@@ -161,11 +180,26 @@ export async function autocomplete(query: string): Promise<string[]> {
 
   let result: string[];
   if (!asciiQuery.includes('.') && !asciiQuery.includes('-')) {
-    // Simple prefix search for short queries
+    // Simple prefix search for short queries. Search both domain (for
+    // ASCII and Punycode-form queries) and domainUnicode (for partial
+    // IDN queries like "прайм").
     const dsps = await prisma.domainSelectorPair.findMany({
       distinct: ['domain'],
       where: {
-        domain: { startsWith: asciiQuery, mode: Prisma.QueryMode.insensitive },
+        OR: [
+          {
+            domain: {
+              startsWith: asciiQuery,
+              mode: Prisma.QueryMode.insensitive,
+            },
+          },
+          {
+            domainUnicode: {
+              startsWith: query,
+              mode: Prisma.QueryMode.insensitive,
+            },
+          },
+        ],
       },
       orderBy: { domain: 'asc' },
       take: remainingSlots,
@@ -176,7 +210,7 @@ export async function autocomplete(query: string): Promise<string[]> {
     // Multi-strategy search for queries with dots/dashes
     const dsps = await prisma.domainSelectorPair.findMany({
       distinct: ['domain'],
-      where: buildDomainFilter(asciiQuery),
+      where: buildDomainFilter(asciiQuery, query),
       orderBy: { domain: 'asc' },
       take: remainingSlots,
       select: { domain: true },
@@ -271,10 +305,12 @@ export async function searchDomain(
   }
 
   // Encode IDN inputs to Punycode before any DB lookup. ASCII queries
-  // pass through unchanged.
+  // pass through unchanged. domainQuery (original, possibly Unicode)
+  // is also passed through so buildDomainFilter can search the
+  // domainUnicode column for partial-IDN matches.
   const asciiQuery = toPunycode(domainQuery);
   const isFirstPage = cursorIndex === null;
-  const domainFilter = buildDomainFilter(asciiQuery);
+  const domainFilter = buildDomainFilter(asciiQuery, domainQuery);
 
   // All three queries are independent on page 1 and run in parallel,
   // saving 2 cross-cloud round trips (~270 ms baseline) and overlapping

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -47,21 +47,41 @@ function toUnicode(domain: string): string {
   return domainToUnicode(domain) || domain;
 }
 
-// Pick the display form for a domain so the user can see WHY it matched
-// their query. ASCII queries like `--` find IDN domains via their `xn--`
-// Punycode prefix; without this helper we would display those matches in
-// Unicode form (which doesn't contain `--`) and the user would think the
-// result was unrelated. Conversely, when the user typed a Unicode IDN
-// query, we want to keep the nicer Unicode display.
+// Decide whether a matched domain should be shown to the user and in
+// which form (Unicode vs Punycode). Three cases:
 //
-// Rule: if the human-readable Unicode form contains the query, show
-// Unicode. Otherwise show the raw Punycode (which is what actually
-// matched).
-function pickDomainDisplay(punycodeDomain: string, query: string): string {
+//   1. Query appears in the human-readable Unicode form. Always show,
+//      render in Unicode. The normal case for ASCII and full-IDN
+//      queries.
+//
+//   2. Query only matches the Punycode encoding artifacts (e.g. ASCII
+//      query `--` finds IDN domains whose stored `xn--…` prefix
+//      contains `--`). Show only when the user looks like they
+//      explicitly typed Punycode (their query contains "xn-").
+//      Otherwise hide the row entirely; showing `xn--0kqx72g9fffb.biz`
+//      to someone who searched for `--` is just confusing.
+//
+//   3. The query is in neither form (shouldn't normally happen given
+//      our substring filter). Hide.
+function decideDomainDisplay(
+  punycodeDomain: string,
+  query: string
+): { display: string; show: boolean } {
+  const queryLower = query.toLowerCase();
   const unicode = toUnicode(punycodeDomain);
-  return unicode.toLowerCase().includes(query.toLowerCase())
-    ? unicode
-    : punycodeDomain;
+
+  if (unicode.toLowerCase().includes(queryLower)) {
+    return { display: unicode, show: true };
+  }
+
+  if (
+    queryLower.includes('xn-') &&
+    punycodeDomain.toLowerCase().includes(queryLower)
+  ) {
+    return { display: punycodeDomain, show: true };
+  }
+
+  return { display: punycodeDomain, show: false };
 }
 
 // Helper: Build domain search filter with subdomain/variant matching
@@ -130,6 +150,15 @@ export async function autocomplete(query: string): Promise<string[]> {
     return [exactMatch.domain, ...deduped].slice(0, AUTOCOMPLETE_LIMIT);
   };
 
+  // Pick + filter helper so a list of raw Punycode domains becomes the
+  // user-facing display list, dropping rows the user shouldn't see
+  // (see decideDomainDisplay).
+  const toDisplay = (domains: string[]): string[] =>
+    domains
+      .map((d) => decideDomainDisplay(d, query))
+      .filter((r) => r.show)
+      .map((r) => r.display);
+
   let result: string[];
   if (!asciiQuery.includes('.') && !asciiQuery.includes('-')) {
     // Simple prefix search for short queries
@@ -142,9 +171,7 @@ export async function autocomplete(query: string): Promise<string[]> {
       take: remainingSlots,
       select: { domain: true },
     });
-    result = prependExact(dsps.map((d) => d.domain)).map((d) =>
-      pickDomainDisplay(d, query)
-    );
+    result = toDisplay(prependExact(dsps.map((d) => d.domain)));
   } else {
     // Multi-strategy search for queries with dots/dashes
     const dsps = await prisma.domainSelectorPair.findMany({
@@ -166,7 +193,7 @@ export async function autocomplete(query: string): Promise<string[]> {
         return a.localeCompare(b);
       });
 
-    result = prependExact(sorted).map((d) => pickDomainDisplay(d, query));
+    result = toDisplay(prependExact(sorted));
   }
 
   autocompleteCache.set(cacheKey, result);
@@ -205,14 +232,22 @@ export type SearchFilters = {
 
 // Transform DB record to frontend format. `query` is the user's original
 // (possibly Unicode) input; it drives whether we display each domain in
-// Unicode or Punycode form. See pickDomainDisplay for the rule.
+// Unicode or Punycode form. See decideDomainDisplay for the rule.
+//
+// Assumes the caller has already filtered out records where
+// decideDomainDisplay would return show=false (e.g. via a prior pass).
+// Falls back to the Unicode form defensively if the decision somehow
+// disagrees, to avoid a `domain: ''` ending up in the UI.
 function transformToSearchResult(
   record: RecordWithSelector,
   query: string
 ): SearchResult {
+  const decision = decideDomainDisplay(record.domainSelectorPair.domain, query);
   return {
     id: record.id,
-    domain: pickDomainDisplay(record.domainSelectorPair.domain, query),
+    domain: decision.show
+      ? decision.display
+      : toUnicode(record.domainSelectorPair.domain),
     selector: record.domainSelectorPair.selector,
     firstActive: record.firstSeenAt.toISOString(),
     lastActive:
@@ -321,7 +356,17 @@ export async function searchDomain(
     return match && match[1] && match[1].trim().length > 0;
   });
 
-  const searchResults = filteredRecords.map((r) =>
+  // Filter out rows where the user's query only matched Punycode
+  // encoding artifacts (e.g. ASCII `--` finding `xn--…` IDN domains).
+  // The user typed something that has no clear human-readable match in
+  // those rows, so showing them would be confusing. Power users who
+  // want Punycode results explicitly type "xn-" somewhere in the
+  // query; see decideDomainDisplay.
+  const visibleRecords = filteredRecords.filter(
+    (r) => decideDomainDisplay(r.domainSelectorPair.domain, domainQuery).show
+  );
+
+  const searchResults = visibleRecords.map((r) =>
     transformToSearchResult(r, domainQuery)
   );
 

--- a/src/app/search/SelectorDetails.tsx
+++ b/src/app/search/SelectorDetails.tsx
@@ -119,7 +119,15 @@ const SelectorDetails = ({ data }: SelectorDetailsProps) => {
     <div className='flex w-full flex-col gap-6'>
       <div ref={stickyHeaderRef} className='sticky top-0 z-10 bg-foreground'>
         <div className='flex flex-col flex-wrap gap-2'>
-          <div className='flex flex-wrap gap-2'>
+          {/*
+            Cap the height of the domain pill list so a query that
+            returns many matching domains (e.g. "x.com" with thousands
+            of substring hits) doesn't push the rest of the page off
+            screen. Without max-h here the sticky header expands to
+            fill the viewport and the selector details below stay
+            hidden even after clicking a pill.
+          */}
+          <div className='flex max-h-48 flex-wrap gap-2 overflow-y-auto pr-1'>
             <Button
               variant='ghost'
               key='all'

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { type SearchFilters } from '@/app/actions';
 import { DomainSearchResults } from '@/components/DomainSearchResult';
@@ -23,16 +23,22 @@ export default function Home() {
 
   const handleSearchChange = (value: string) => {
     setSearchQuery(value);
-    // Keep URL in sync without triggering an RSC navigation per keystroke.
-    const params = new URLSearchParams(searchParams.toString());
-    if (value) {
-      params.set('q', value);
+    // URL sync is deferred to onSearchSettled below: doing it here
+    // (via replaceState) while the server action is in flight caused
+    // Next.js to refetch the RSC and cancel the action mid-flight,
+    // which left the search UI stuck on "Loading..." (REG-712).
+  };
+
+  const handleSearchSettled = useCallback((query: string) => {
+    const params = new URLSearchParams(window.location.search);
+    if (query) {
+      params.set('q', query);
     } else {
       params.delete('q');
     }
     const qs = params.toString();
     window.history.replaceState(null, '', qs ? `/search?${qs}` : '/search');
-  };
+  }, []);
 
   const handleFilterChange = (value: string) => {
     setStatusFilter(value as 'all' | 'active' | 'expired');
@@ -91,6 +97,7 @@ export default function Home() {
             domainQuery={searchQuery}
             filters={filters}
             onLoadingChange={setIsSearchLoading}
+            onSearchSettled={handleSearchSettled}
           />
         </div>
       </div>

--- a/src/components/DomainSearchResult.tsx
+++ b/src/components/DomainSearchResult.tsx
@@ -13,6 +13,11 @@ interface Props {
   domainQuery: string | undefined;
   filters?: SearchFilters;
   onLoadingChange?: (loading: boolean) => void;
+  // Fires once the latest committed query has settled (success or error).
+  // The parent uses this to sync the URL *after* the server action has
+  // resolved; updating the URL while the action is in flight causes
+  // Next.js to refetch the RSC and cancel the action mid-flight (REG-712).
+  onSearchSettled?: (query: string) => void;
 }
 
 // Check if a record is expired (last seen > 365 days ago)
@@ -58,6 +63,7 @@ export function DomainSearchResults({
   domainQuery,
   filters = {},
   onLoadingChange,
+  onSearchSettled,
 }: Props) {
   const [data, setData] = useState<SearchResponse | null>(null);
   const [loading, setLoading] = useState(false);
@@ -69,7 +75,7 @@ export function DomainSearchResults({
   // Abort-on-new model: each search bumps requestIdRef. A response only
   // updates state if its id still matches; otherwise it was superseded
   // by a newer query and is silently dropped. Loading is true iff the
-  // most recent search hasn't completed yet — older in-flight fetches
+  // most recent search hasn't completed yet. Older in-flight fetches
   // don't own the loading flag, so they can't get it stuck.
   //
   // The previous "queue-latest" implementation kept a separate
@@ -79,29 +85,32 @@ export function DomainSearchResults({
   // continue to run on the server; they just have no client-side effect.
   const requestIdRef = useRef(0);
 
-  const runSearch = useCallback(async (query: string) => {
-    const requestId = ++requestIdRef.current;
-    setLoading(true);
-    try {
-      const response = await searchDomain(query, null);
-      if (requestId !== requestIdRef.current) return;
-      // Guard against the server returning undefined (e.g. dev-mode
-      // stale-server-action errors); keep data null in that case.
-      setData(response ?? null);
-      setError(null);
-    } catch (err) {
-      if (requestId !== requestIdRef.current) return;
-      setError('Failed to load search results');
-      console.error('Search error:', err);
-    } finally {
-      // Only the latest request owns the loading flag. A stale response
-      // landing late must not flip loading off while a newer search is
-      // still pending.
-      if (requestId === requestIdRef.current) {
-        setLoading(false);
+  const runSearch = useCallback(
+    async (query: string) => {
+      const requestId = ++requestIdRef.current;
+      setLoading(true);
+      try {
+        const response = await searchDomain(query, null);
+        if (requestId !== requestIdRef.current) return;
+        setData(response ?? null);
+        setError(null);
+      } catch (err) {
+        if (requestId !== requestIdRef.current) return;
+        setError('Failed to load search results');
+        console.error('Search error:', err);
+      } finally {
+        // Only the latest request owns the loading flag. A stale response
+        // landing late must not flip loading off while a newer search is
+        // still pending.
+        const isLatest = requestId === requestIdRef.current;
+        if (isLatest) {
+          setLoading(false);
+          onSearchSettled?.(query);
+        }
       }
-    }
-  }, []);
+    },
+    [onSearchSettled]
+  );
 
   const loadRecords = useCallback(() => {
     if (!domainQuery) {
@@ -109,14 +118,15 @@ export function DomainSearchResults({
       setData(null);
       setError(null);
       setLoading(false);
+      onSearchSettled?.('');
       return;
     }
     runSearch(domainQuery);
-  }, [domainQuery, runSearch]);
+  }, [domainQuery, runSearch, onSearchSettled]);
 
   useEffect(() => {
     loadRecords();
-  }, [loadRecords]);
+  }, [loadRecords, domainQuery]);
 
   // Mirror the committed-search loading state up to the parent so the
   // SearchAndFilterSection magnifier button can show a spinner while the

--- a/src/components/DomainSearchResult.tsx
+++ b/src/components/DomainSearchResult.tsx
@@ -66,65 +66,53 @@ export function DomainSearchResults({
   const sentinelRef = useRef<HTMLDivElement>(null);
 
   const loadingMoreRef = useRef(false);
-  // Serialize searches: at most one request in flight at a time. While one
-  // is running, the latest query is stashed in pendingQueryRef and fired
-  // when the current request settles. Server actions can't be aborted, so
-  // this is how we prevent the backend from being hammered by per-keystroke
-  // requests during slow typing.
-  const inFlightRef = useRef(false);
-  const pendingQueryRef = useRef<string | null>(null);
+  // Abort-on-new model: each search bumps requestIdRef. A response only
+  // updates state if its id still matches; otherwise it was superseded
+  // by a newer query and is silently dropped. Loading is true iff the
+  // most recent search hasn't completed yet — older in-flight fetches
+  // don't own the loading flag, so they can't get it stuck.
+  //
+  // The previous "queue-latest" implementation kept a separate
+  // pendingQueryRef + inFlightRef + a while loop; it had an edge case
+  // where rapid query changes left the loading state stuck on (REG-712).
+  // Server actions still can't be aborted client-side, so older fetches
+  // continue to run on the server; they just have no client-side effect.
   const requestIdRef = useRef(0);
 
-  const runSearchQueue = useCallback(async (initialQuery: string) => {
-    if (inFlightRef.current) {
-      pendingQueryRef.current = initialQuery;
-      return;
-    }
-
-    inFlightRef.current = true;
-    let current = initialQuery;
-
+  const runSearch = useCallback(async (query: string) => {
+    const requestId = ++requestIdRef.current;
+    setLoading(true);
     try {
-      while (current) {
-        const requestId = ++requestIdRef.current;
-        try {
-          const response = await searchDomain(current, null);
-          if (requestId === requestIdRef.current) {
-            // Guard against the server returning undefined (e.g. dev-mode
-            // stale-server-action errors) — keep data null in that case.
-            setData(response ?? null);
-            setError(null);
-          }
-        } catch (err) {
-          if (requestId === requestIdRef.current) {
-            setError('Failed to load search results');
-            console.error('Search error:', err);
-          }
-        }
-
-        const next = pendingQueryRef.current;
-        pendingQueryRef.current = null;
-        if (!next || next === current) break;
-        current = next;
-      }
+      const response = await searchDomain(query, null);
+      if (requestId !== requestIdRef.current) return;
+      // Guard against the server returning undefined (e.g. dev-mode
+      // stale-server-action errors); keep data null in that case.
+      setData(response ?? null);
+      setError(null);
+    } catch (err) {
+      if (requestId !== requestIdRef.current) return;
+      setError('Failed to load search results');
+      console.error('Search error:', err);
     } finally {
-      inFlightRef.current = false;
-      setLoading(false);
+      // Only the latest request owns the loading flag. A stale response
+      // landing late must not flip loading off while a newer search is
+      // still pending.
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
     }
   }, []);
 
   const loadRecords = useCallback(() => {
     if (!domainQuery) {
       requestIdRef.current += 1;
-      pendingQueryRef.current = null;
       setData(null);
       setError(null);
       setLoading(false);
       return;
     }
-    setLoading(true);
-    runSearchQueue(domainQuery);
-  }, [domainQuery, runSearchQueue]);
+    runSearch(domainQuery);
+  }, [domainQuery, runSearch]);
 
   useEffect(() => {
     loadRecords();

--- a/src/lib/utilsServer.ts
+++ b/src/lib/utilsServer.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { domainToUnicode } from 'node:url';
 
 import * as crypto from 'crypto';
 import dns from 'dns';
@@ -74,9 +75,18 @@ export async function addDomainSelectorPair(
     return { already_in_db: false, added: false };
   }
 
+  // Populate domainUnicode alongside domain so partial-IDN substring
+  // search (REG-711) can match the decoded form. For ASCII domains this
+  // equals `domain`. For Punycode IDN domains (`xn--…`) this is the
+  // decoded Unicode label (e.g. "прайм19.рф"). domainToUnicode returns
+  // an empty string for unparseable input, so we fall back to `domain`
+  // defensively.
+  const domainUnicode = (domainToUnicode(domain) || domain).toLowerCase();
+
   await prisma.domainSelectorPair.create({
     data: {
       domain,
+      domainUnicode,
       selector,
       sourceIdentifier,
       lastRecordUpdate: new Date(),


### PR DESCRIPTION
## Summary

Round 4 of QA feedback. Four tickets resolved:

- **REG-710** Domain pill list in the sticky details header could grow unbounded for domains with many DKIM selectors. Capped the flex container at `max-h-48` with `overflow-y-auto`.
- **REG-709** Search for ASCII queries was surfacing Punycode-encoded IDN domains in their `xn--` form. Now the displayed form is decided per match: Unicode when the user typed a plain ASCII or Unicode query, Punycode only when the user explicitly typed an `xn-` prefix. Punycode-only matches are filtered out unless the user opts in.
- **REG-711** Partial-IDN substring search (e.g. `прайм` finding `прайм19.рф`) did not work because the database stored only the Punycode form. Added a denormalized `domainUnicode` column to `DomainSelectorPair` with a GIN trigram index, populated it on every insert, backfilled existing rows, and made the query layer pick one column per query (Punycode mode targets `domain`, otherwise `domainUnicode`).
- **REG-712** Results stuck on `Loading...` when the user committed a new query while a previous search was still in flight. Two-part fix:
  1. Replaced the queue-latest model with abort-on-new: each search bumps a `requestIdRef`, and only the latest response is allowed to update state.
  2. Deferred URL sync to `onSearchSettled`. Calling `window.history.replaceState` while the server action was in flight was triggering an RSC refetch that canceled the action mid-flight, so its promise never resolved on the client. Now we update the URL only after the latest committed search has settled.

## Test plan

- [x] REG-710: open a domain with many selectors, confirm the pill list scrolls and does not push the rest of the header off-screen.
- [x] REG-709: search ASCII queries, confirm no `xn--` rows appear in results; search `xn-` prefix, confirm Punycode rows reappear.
- [x] REG-711: search `прайм`, confirm `прайм19.рф` appears; search other Cyrillic prefixes from real seeded rows.
- [x] REG-712: load `/search?q=--`, change input to `xn--`, press Enter, confirm results load and URL updates to `/search?q=xn--`. Repeat with rapid query changes and confirm nothing gets stuck on Loading.
- [x] Refresh on `/search?q=прайм19.рф` and confirm results still load (URL sharing still works).
- [x] Production build passes (verified by pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gmail OAuth authentication and email-based DKIM pair uploads
  * Implemented DKIM record search API with autocomplete suggestions
  * Created archive statistics API and dashboard display showing unique domains and DKIM keys
  * Added JWT key set viewer interface

* **Documentation**
  * Updated architecture and getting-started guides
  * Added Prisma 7 migration notes

* **Chores**
  * Updated dependencies and Node.js version
  * Configured Docker container support and cloud deployment infrastructure
  * Implemented API key and rate limiting system

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zkemail/archive/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->