### PR TITLE
fix: sticky search bar so users can re-search without scrolling back (REG-715)

### DIFF
--- a/src/app/search/SelectorDetails.tsx
+++ b/src/app/search/SelectorDetails.tsx
@@ -117,7 +117,11 @@ const SelectorDetails = ({ data }: SelectorDetailsProps) => {
 
   return (
     <div className='flex w-full flex-col gap-6'>
-      <div ref={stickyHeaderRef} className='sticky top-0 z-10 bg-foreground'>
+      <div
+        ref={stickyHeaderRef}
+        className='sticky z-10 bg-foreground'
+        style={{ top: 'var(--search-header-height, 0px)' }}
+      >
         <div className='flex flex-col flex-wrap gap-2'>
           {/*
             Cap the height of the domain pill list so a query that

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { type SearchFilters } from '@/app/actions';
 import { DomainSearchResults } from '@/components/DomainSearchResult';
@@ -61,6 +61,29 @@ export default function Home() {
     [statusFilter, fromDate, toDate]
   );
 
+  // Measure the sticky search-and-filter header and expose its height
+  // as a CSS variable so the sticky pill list below it can stack with
+  // the right offset instead of overlapping. ResizeObserver keeps the
+  // value live across viewport / content changes.
+  const searchHeaderRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const el = searchHeaderRef.current;
+    if (!el) return;
+    const update = () => {
+      document.documentElement.style.setProperty(
+        '--search-header-height',
+        `${el.offsetHeight}px`
+      );
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => {
+      ro.disconnect();
+      document.documentElement.style.removeProperty('--search-header-height');
+    };
+  }, []);
+
   return (
     <div className='my-8 flex flex-1 flex-col items-center'>
       <div className='relative mx-auto aspect-12/5 w-14/15 max-w-[720px] overflow-clip rounded-t-3xl border border-border md:aspect-9/2'>
@@ -83,7 +106,10 @@ export default function Home() {
         />
       </div>
       <div className='flex w-14/15 max-w-[720px] flex-col items-start justify-start gap-6 rounded-br-3xl rounded-bl-3xl border-r border-b border-l border-border bg-foreground p-6'>
-        <div className='flex flex-col items-start justify-start gap-2 self-stretch'>
+        <div
+          ref={searchHeaderRef}
+          className='sticky top-0 z-20 flex flex-col items-start justify-start gap-2 self-stretch bg-foreground pb-2'
+        >
           <SearchAndFilterSection
             initialQuery={initialQuery}
             onSearchChange={handleSearchChange}


### PR DESCRIPTION
## Summary

QA follow-up to REG-710 (round 4). After the pill list cap, users reported that once they had scrolled down through selector details, getting back to the search form was awkward. The sticky header only carried the pill list, and the inner `overflow-y-auto` on the pill list trapped trackpad momentum so wheel-up didn't reliably chain to the page.

Instead of fighting scroll chaining or adding auto-scroll-on-boundary heuristics, this PR sticks the search input + filter section to the top of the viewport alongside the pill list. The user never needs to scroll back to re-search because the search bar is always visible.

## Changes

- `src/app/search/page.tsx`: wrap `SearchAndFilterSection` in a sticky container, measure its height with a `ResizeObserver`, and publish it as a `--search-header-height` CSS custom property so the pill list below can stack with the right offset.
- `src/app/search/SelectorDetails.tsx`: change the pill list's sticky offset from `top-0` to `var(--search-header-height, 0px)` so it sits directly below the sticky search bar instead of overlapping.

Closes REG-715.

## Test plan

- [x] Search "aa" or anything with many domain matches, scroll down through results, confirm both the search input and the pill list stay glued to the top of the viewport (stacked, no overlap).
- [x] Type a new query into the sticky search bar at any scroll depth, confirm it works without scrolling up.
- [x] Confirm no visual regression for small result sets where nothing was being pushed off-screen before.
- [x] Resize the browser window, confirm the pill list's offset updates so it stays directly below the search bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)