### PR TITLE
fix: anchor ActivityChart timeframes to lastActive (REG-716)

### DIFF
--- a/src/app/search/ActivityChart.tsx
+++ b/src/app/search/ActivityChart.tsx
@@ -1,5 +1,5 @@
 import { InfoIcon } from '@phosphor-icons/react';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Area, AreaChart, ResponsiveContainer, XAxis, YAxis } from 'recharts';
 
 import { Button } from '@/components/ui/button';
@@ -19,103 +19,122 @@ const ActivityChart = ({
 }) => {
   const [selectedTimeframe, setSelectedTimeframe] = useState('12M');
 
-  const { availableTimeframes, data, chartWidth } = useMemo(() => {
-    const now = new Date();
-    const totalDays = Math.ceil(
-      (now.getTime() - firstActive.getTime()) / (1000 * 60 * 60 * 24)
-    );
+  const scrollRef = useRef<HTMLDivElement | null>(null);
 
-    const timeframeDays = {
-      '12M': 365,
-      '3Y': 365 * 3,
-      '5Y': 365 * 5,
-      '10Y': 365 * 10,
-    };
+  const { availableTimeframes, data, chartWidth, isolatedBarWidth } =
+    useMemo(() => {
+      const timeframeDays = {
+        '12M': 365,
+        '3Y': 365 * 3,
+        '5Y': 365 * 5,
+        '10Y': 365 * 10,
+      };
 
-    const availableTimeframes = Object.keys(timeframeDays).filter(
-      (tf) => totalDays >= timeframeDays[tf as keyof typeof timeframeDays] * 0.5
-    );
+      // All timeframes are always selectable. Younger selectors still get
+      // a useful chart: the window is anchored to lastActive, so 10Y on a
+      // 2-year-old selector just shows 8 years of empty months followed by
+      // the active span at the right edge.
+      const availableTimeframes = Object.keys(timeframeDays);
 
-    const currentTimeframe = availableTimeframes.includes(selectedTimeframe)
-      ? selectedTimeframe
-      : availableTimeframes[0] || '12M';
+      const currentTimeframe = availableTimeframes.includes(selectedTimeframe)
+        ? selectedTimeframe
+        : availableTimeframes[0] || '12M';
 
-    // Use month-based stepping to avoid duplicate labels
-    let stepMonths = 1;
-    if (currentTimeframe === '12M') stepMonths = 1;
-    else if (currentTimeframe === '3Y') stepMonths = 2;
-    else if (currentTimeframe === '5Y') stepMonths = 3;
-    else if (currentTimeframe === '10Y') stepMonths = 6;
+      // Use month-based stepping to avoid duplicate labels
+      let stepMonths = 1;
+      if (currentTimeframe === '12M') stepMonths = 1;
+      else if (currentTimeframe === '3Y') stepMonths = 2;
+      else if (currentTimeframe === '5Y') stepMonths = 3;
+      else if (currentTimeframe === '10Y') stepMonths = 6;
 
-    const timeframeDuration =
-      timeframeDays[currentTimeframe as keyof typeof timeframeDays];
+      const timeframeDuration =
+        timeframeDays[currentTimeframe as keyof typeof timeframeDays];
 
-    // Anchor the chart end to lastActive so expired selectors render
-    // their activity at the right edge instead of being squashed against
-    // the y-axis. For active selectors lastActive is ~now, so behavior
-    // is effectively unchanged.
-    const endDate = new Date(lastActive);
-    const idealStartDate = new Date(endDate);
-    idealStartDate.setDate(idealStartDate.getDate() - timeframeDuration);
+      // Anchor the chart end to lastActive so expired selectors render
+      // their activity at the right edge instead of being squashed against
+      // the y-axis. For active selectors lastActive is ~now, so behavior
+      // is effectively unchanged.
+      const endDate = new Date(lastActive);
+      const idealStartDate = new Date(endDate);
+      idealStartDate.setDate(idealStartDate.getDate() - timeframeDuration);
 
-    // Snap to the first of the month, with 1 month buffer before the start.
-    const timeframeStartDate = new Date(
-      idealStartDate.getFullYear(),
-      idealStartDate.getMonth() - 1,
-      1
-    );
+      // Snap to the first of the month so labels line up with month
+      // boundaries instead of falling mid-month.
+      const timeframeStartDate = new Date(
+        idealStartDate.getFullYear(),
+        idealStartDate.getMonth(),
+        1
+      );
 
-    const dataPoints = [];
-    const current = new Date(timeframeStartDate);
+      const dataPoints = [];
+      const current = new Date(timeframeStartDate);
 
-    while (current <= endDate) {
-      // Each x-axis label is a bucket of `stepMonths` months. Mark the
-      // bucket active if it overlaps [firstActive, lastActive] so a
-      // sub-step active window (e.g. only May 2015 with a 6-month step)
-      // still surfaces a marker.
-      const currentMonth = current.getFullYear() * 12 + current.getMonth();
-      const bucketEndMonth = currentMonth + stepMonths - 1;
-      const firstMonth =
-        firstActive.getFullYear() * 12 + firstActive.getMonth();
-      const lastMonth = lastActive.getFullYear() * 12 + lastActive.getMonth();
-      const isInActivePeriod =
-        bucketEndMonth >= firstMonth && currentMonth <= lastMonth;
+      while (current <= endDate) {
+        // Each x-axis label is a bucket of `stepMonths` months. Mark the
+        // bucket active if it overlaps [firstActive, lastActive] so a
+        // sub-step active window (e.g. only May 2015 with a 6-month step)
+        // still surfaces a marker.
+        const currentMonth = current.getFullYear() * 12 + current.getMonth();
+        const bucketEndMonth = currentMonth + stepMonths - 1;
+        const firstMonth =
+          firstActive.getFullYear() * 12 + firstActive.getMonth();
+        const lastMonth = lastActive.getFullYear() * 12 + lastActive.getMonth();
+        const isInActivePeriod =
+          bucketEndMonth >= firstMonth && currentMonth <= lastMonth;
 
-      const dateLabel =
-        currentTimeframe === '5Y' || currentTimeframe === '10Y'
-          ? current.toLocaleDateString('en-US', {
-              month: 'short',
-              year: 'numeric',
-            })
-          : current.toLocaleDateString('en-US', {
-              month: 'short',
-              year: '2-digit',
-            });
+        const dateLabel = current.toLocaleDateString('en-US', {
+          month: 'short',
+          year: 'numeric',
+        });
 
-      dataPoints.push({
-        date: dateLabel,
-        fullDate: current.toISOString().split('T')[0],
-        activity: isInActivePeriod ? 8 : null,
-        timestamp: current.getTime(),
-      });
+        dataPoints.push({
+          date: dateLabel,
+          fullDate: current.toISOString().split('T')[0],
+          activity: isInActivePeriod ? 8 : null,
+          timestamp: current.getTime(),
+        });
 
-      current.setMonth(current.getMonth() + stepMonths);
-    }
+        current.setMonth(current.getMonth() + stepMonths);
+      }
 
-    let minWidthPerPoint = 50;
-    if (currentTimeframe === '12M') minWidthPerPoint = 70;
-    else if (currentTimeframe === '3Y') minWidthPerPoint = 60;
-    else if (currentTimeframe === '5Y') minWidthPerPoint = 50;
-    else if (currentTimeframe === '10Y') minWidthPerPoint = 45;
+      // Pixels per label slot. "MMM YYYY" ("Nov 2025") is ~55px wide at
+      // 12px font, so 75 gives breathing room between adjacent labels even
+      // when every tick is rendered (no auto-skipping below).
+      const minWidthPerPoint = 75;
 
-    const calculatedWidth = Math.max(600, dataPoints.length * minWidthPerPoint);
+      const calculatedWidth = Math.max(
+        600,
+        dataPoints.length * minWidthPerPoint
+      );
 
-    return {
-      availableTimeframes,
-      data: dataPoints,
-      chartWidth: calculatedWidth,
-    };
-  }, [firstActive, lastActive, selectedTimeframe]);
+      // Visual width of the isolated-bucket marker (when only one bucket
+      // is active in the chart, e.g. an expired key whose first/last seen
+      // are in the same month). Sized as ~40% of one bucket so a single
+      // month reads as a narrow block instead of filling its whole slot,
+      // with a min so very dense timeframes still show something.
+      const perPointWidth = calculatedWidth / Math.max(dataPoints.length, 1);
+      const isolatedBarWidth = Math.max(6, Math.floor(perPointWidth * 0.2));
+
+      return {
+        availableTimeframes,
+        data: dataPoints,
+        chartWidth: calculatedWidth,
+        isolatedBarWidth,
+      };
+    }, [firstActive, lastActive, selectedTimeframe]);
+
+  // The chart window ends at lastActive, so activity always lives at
+  // the right edge of the scrollable area. Scroll there on mount and
+  // when the timeframe changes so the user sees the active region
+  // immediately instead of an empty left side.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const id = requestAnimationFrame(() => {
+      el.scrollLeft = el.scrollWidth;
+    });
+    return () => cancelAnimationFrame(id);
+  }, [chartWidth, selectedTimeframe]);
 
   return (
     <div className='w-full rounded-lg bg-foreground'>
@@ -160,7 +179,7 @@ const ActivityChart = ({
           ))}
         </div>
       </div>
-      <div className='w-full overflow-x-auto'>
+      <div ref={scrollRef} className='w-full overflow-x-auto'>
         <div className={`h-16 min-w-full`} style={{ width: `${chartWidth}px` }}>
           <ResponsiveContainer width='100%' height='100%'>
             <AreaChart
@@ -196,6 +215,14 @@ const ActivityChart = ({
                 tickLine={false}
                 tick={{ fontSize: 12, fill: '#6b7280' }}
                 dy={3}
+                // Render every label — minWidthPerPoint above is sized
+                // so MMM YYYY labels don't overlap, and per-product
+                // direction is "scrolling can be longer".
+                interval={0}
+                // Give the first and last labels half a label-width of
+                // breathing room inside the plot area so they don't
+                // clip against the scroll container edges.
+                padding={{ left: 30, right: 30 }}
               />
               <YAxis hide domain={[0, 10]} />
               <Area
@@ -204,12 +231,18 @@ const ActivityChart = ({
                 stroke='#22c55e'
                 strokeWidth={1}
                 fill='url(#activityGradient)'
-                // Recharts <Area> can't render a single isolated non-null
-                // point — for selectors with a sub-bucket activity window
-                // (e.g. first and last seen in the same month) the area
-                // would otherwise be completely invisible. Draw an explicit
-                // green dot in that case so short-lived selectors still
-                // show up on the chart.
+                // Recharts <Area> can't render an isolated single
+                // active data point (with null neighbours): the area
+                // path between two null points has zero width. For
+                // selectors whose activity window fits inside a single
+                // bucket on the current timeframe (e.g. first and last
+                // seen in the same month on the 12M view) draw an
+                // explicit bucket-wide block so they remain visible.
+                //
+                // Geometry note: data value is fixed at 8 with a [0,10]
+                // y-domain, so cy sits at 20% of the plot height from
+                // the top. The plot bottom is therefore at 5*cy and
+                // the bar height from cy down to the bottom is 4*cy.
                 dot={(dotProps: {
                   cx?: number;
                   cy?: number;
@@ -233,8 +266,26 @@ const ActivityChart = ({
                     (!prev || prev.activity === null) &&
                     (!next || next.activity === null);
                   if (!isIsolated) return <g key={key} />;
+                  const halfBar = isolatedBarWidth / 2;
+                  const barHeight = Math.max(0, cy * 4);
                   return (
-                    <circle key={key} cx={cx} cy={cy} r={4} fill='#22c55e' />
+                    <g key={key}>
+                      <rect
+                        x={cx - halfBar}
+                        y={cy}
+                        width={isolatedBarWidth}
+                        height={barHeight}
+                        fill='url(#activityGradient)'
+                      />
+                      <line
+                        x1={cx - halfBar}
+                        y1={cy}
+                        x2={cx + halfBar}
+                        y2={cy}
+                        stroke='#22c55e'
+                        strokeWidth={1}
+                      />
+                    </g>
                   );
                 }}
                 connectNulls={false}

--- a/src/app/search/ActivityChart.tsx
+++ b/src/app/search/ActivityChart.tsx
@@ -49,29 +49,37 @@ const ActivityChart = ({
 
     const timeframeDuration =
       timeframeDays[currentTimeframe as keyof typeof timeframeDays];
-    const idealStartDate = new Date(now);
+
+    // Anchor the chart end to lastActive so expired selectors render
+    // their activity at the right edge instead of being squashed against
+    // the y-axis. For active selectors lastActive is ~now, so behavior
+    // is effectively unchanged.
+    const endDate = new Date(lastActive);
+    const idealStartDate = new Date(endDate);
     idealStartDate.setDate(idealStartDate.getDate() - timeframeDuration);
 
-    // Snap to the first of the month, with at least 1 month buffer before active period
-    const startDate =
-      firstActive < idealStartDate ? firstActive : idealStartDate;
+    // Snap to the first of the month, with 1 month buffer before the start.
     const timeframeStartDate = new Date(
-      startDate.getFullYear(),
-      startDate.getMonth() - 1,
+      idealStartDate.getFullYear(),
+      idealStartDate.getMonth() - 1,
       1
     );
 
     const dataPoints = [];
     const current = new Date(timeframeStartDate);
 
-    while (current <= now) {
-      // Compare by month to avoid off-by-days issues with 1st-of-month snapping
+    while (current <= endDate) {
+      // Each x-axis label is a bucket of `stepMonths` months. Mark the
+      // bucket active if it overlaps [firstActive, lastActive] so a
+      // sub-step active window (e.g. only May 2015 with a 6-month step)
+      // still surfaces a marker.
       const currentMonth = current.getFullYear() * 12 + current.getMonth();
+      const bucketEndMonth = currentMonth + stepMonths - 1;
       const firstMonth =
         firstActive.getFullYear() * 12 + firstActive.getMonth();
       const lastMonth = lastActive.getFullYear() * 12 + lastActive.getMonth();
       const isInActivePeriod =
-        currentMonth >= firstMonth && currentMonth <= lastMonth;
+        bucketEndMonth >= firstMonth && currentMonth <= lastMonth;
 
       const dateLabel =
         currentTimeframe === '5Y' || currentTimeframe === '10Y'


### PR DESCRIPTION
## Summary

Fixes Activity chart issues reported in QA round 4, plus follow-up tuning of label format, axis range, scroll position, and isolated-bucket rendering.

Linear: [REG-716](https://linear.app/zk-email/issue/REG-716)

## What changed

### Window anchored to lastActive
The chart window now ends at `lastActive` and extends back by exactly the selected timeframe duration. Previously the window extended back to `firstActive` whenever `firstActive` was older than the ideal start, so "12M" on an 11-year-old expired key spanned 11 years and the activity sat at the far-left edge of the chart, hidden behind the y-axis.

For docs.google.com `20120806` (Expired, May 12 -> May 14 2015), today 2026-05-28:
| Tab | Range (data) |
|-----|--------------|
| 12M | May 2014 -> May 2015 |
| 3Y  | May 2012 -> May 2015 |
| 5Y  | May 2010 -> May 2015 |
| 10Y | May 2005 -> May 2015 |

### Bucket-overlap active check
Active status is now true when any month inside the bucket overlaps `[firstActive, lastActive]`, not when the bucket's left edge does. Prevents the 3Y / 5Y / 10Y views from skipping a single-month active period that lands between two step boundaries.

### All timeframes always selectable
Dropped the `availableTimeframes` age filter. With the window anchored to `lastActive`, 10Y on a 2-year-old key is still meaningful (most of the chart is empty months, then the active span at the right edge).

### Label format: `MMM YYYY` for all timeframes, every tick rendered
Switched to `month: 'short'`, `year: 'numeric'` across the board, set `interval={0}` on the XAxis so Recharts no longer auto-hides labels, bumped `minWidthPerPoint` to 75px so they have room to breathe, and added `padding={{ left: 30, right: 30 }}` so the first and last labels don't clip against the scroll container.

### Auto-scroll to the active region on open
On mount / tab switch the chart's overflow container scrolls itself to `scrollLeft = scrollWidth`. Activity always lives at the right edge (because of the lastActive anchor), so this lands directly on the active region without the user having to scroll there.

### Narrow isolated-bucket marker
For selectors whose entire activity span fits in a single bucket (Recharts `<Area>` can't render an isolated active data point because the path between two `null`s has zero width), the dot callback draws an explicit bar centred on the data point. Sized at ~20% of one bucket width so it reads as "this thing was active in this month" rather than filling the whole bucket. Half a single-month width on a shoulder extension was considered but reverted — the dot callback renders synchronously while the Area animation sweeps in, and the timing/visual mismatch was worse than not having shoulders.

## Test plan

- [x] `/search?q=docs.google.com` -> expand `20120806`. Each timeframe shows its advertised duration ending in May 2015, narrow green block visible at the right edge of every view.
- [x] Same page -> expand `20230601`. Each timeframe shows its advertised duration ending Nov 2025, multi-bucket green band from Feb 2024 onwards.
- [x] All four tabs (12M / 3Y / 5Y / 10Y) are enabled on both selectors.
- [x] X-axis labels read `MMM YYYY` (`May 2015`, `Nov 2025`) and never clip at the edges.
- [x] On open, the chart is already scrolled to the active region — no horizontal scroll needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)