### PR TITLE
feat: port /api/batch_update from legacy archive for DKIM refresh (REG-717)

### DIFF
--- a/src/app/api/batch_update/route.ts
+++ b/src/app/api/batch_update/route.ts
@@ -1,0 +1,74 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { prisma, updateDspTimestamp } from '@/lib/db';
+import { logger } from '@/lib/logger';
+import { guessSelectors } from '@/lib/selectorGuesser';
+import { fetchAndStoreDkimDnsRecord } from '@/lib/utilsServer';
+
+// Ported from zkemail/archive.zk.email:src/app/api/batch_update/route.ts.
+// Polled every minute by a GCE-hosted cron (see REG-717).
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const batchSizeParam = request.nextUrl.searchParams.get('batch_size');
+  const batchSize = Number(batchSizeParam || '10');
+  if (!Number.isFinite(batchSize) || batchSize <= 0 || batchSize > 1000) {
+    return NextResponse.json(
+      { error: 'batch_size must be a positive integer ≤ 1000' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const oneDayAgo = new Date(Date.now() - 1000 * 60 * 60 * 24);
+    const dsps = await prisma.domainSelectorPair.findMany({
+      where: { lastRecordUpdate: { lte: oneDayAgo } },
+      orderBy: { lastRecordUpdate: 'asc' },
+      take: batchSize,
+    });
+
+    logger.info('batch_update_start', {
+      requested: batchSize,
+      found: dsps.length,
+    });
+
+    const addedAlternatives: { domain: string; selector: string }[] = [];
+    const now = new Date();
+    for (const dsp of dsps) {
+      try {
+        await fetchAndStoreDkimDnsRecord(dsp);
+        await updateDspTimestamp(dsp, now);
+        addedAlternatives.push(
+          ...(await guessSelectors(dsp.domain, dsp.selector, now))
+        );
+      } catch (error) {
+        logger.error('batch_update_dsp_failed', {
+          domain: dsp.domain,
+          selector: dsp.selector,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        // Match the legacy behavior: abort the batch on first per-DSP failure
+        // so the cron retries the same window next run.
+        throw error;
+      }
+    }
+
+    return NextResponse.json(
+      { updatedRecords: dsps, addedAlternatives },
+      { status: 200 }
+    );
+  } catch (error) {
+    logger.error('batch_update_failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/batch_update/route.ts
+++ b/src/app/api/batch_update/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
 
   const batchSizeParam = request.nextUrl.searchParams.get('batch_size');
   const batchSize = Number(batchSizeParam || '10');
-  if (!Number.isFinite(batchSize) || batchSize <= 0 || batchSize > 1000) {
+  if (!Number.isInteger(batchSize) || batchSize <= 0 || batchSize > 1000) {
     return badRequest('batch_size must be a positive integer <= 1000');
   }
 

--- a/src/app/api/batch_update/route.ts
+++ b/src/app/api/batch_update/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
+import { badRequest, serverError } from '@/lib/api-response';
 import { prisma, updateDspTimestamp } from '@/lib/db';
 import { logger } from '@/lib/logger';
 import { guessSelectors } from '@/lib/selectorGuesser';
@@ -18,10 +19,7 @@ export async function GET(request: NextRequest) {
   const batchSizeParam = request.nextUrl.searchParams.get('batch_size');
   const batchSize = Number(batchSizeParam || '10');
   if (!Number.isFinite(batchSize) || batchSize <= 0 || batchSize > 1000) {
-    return NextResponse.json(
-      { error: 'batch_size must be a positive integer ≤ 1000' },
-      { status: 400 }
-    );
+    return badRequest('batch_size must be a positive integer <= 1000');
   }
 
   try {
@@ -38,10 +36,10 @@ export async function GET(request: NextRequest) {
     });
 
     const addedAlternatives: { domain: string; selector: string }[] = [];
-    const now = new Date();
     for (const dsp of dsps) {
       try {
         await fetchAndStoreDkimDnsRecord(dsp);
+        const now = new Date();
         await updateDspTimestamp(dsp, now);
         addedAlternatives.push(
           ...(await guessSelectors(dsp.domain, dsp.selector, now))
@@ -66,9 +64,6 @@ export async function GET(request: NextRequest) {
     logger.error('batch_update_failed', {
       error: error instanceof Error ? error.message : String(error),
     });
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : String(error) },
-      { status: 500 }
-    );
+    return serverError();
   }
 }

--- a/src/lib/selectorGuesser.ts
+++ b/src/lib/selectorGuesser.ts
@@ -1,6 +1,6 @@
-import { logger } from './logger';
-import { type DomainAndSelector, isValidDate } from './utils';
-import { addDomainSelectorPair } from './utilsServer';
+import { logger } from '@/lib/logger';
+import { type DomainAndSelector, isValidDate } from '@/lib/utils';
+import { addDomainSelectorPair } from '@/lib/utilsServer';
 
 function dateToYYYYMMDD(date: Date): string {
   return `${date.getFullYear()}${(date.getMonth() + 1).toString().padStart(2, '0')}${date.getDate().toString().padStart(2, '0')}`;

--- a/src/lib/selectorGuesser.ts
+++ b/src/lib/selectorGuesser.ts
@@ -1,0 +1,121 @@
+import { logger } from './logger';
+import { type DomainAndSelector, isValidDate } from './utils';
+import { addDomainSelectorPair } from './utilsServer';
+
+function dateToYYYYMMDD(date: Date): string {
+  return `${date.getFullYear()}${(date.getMonth() + 1).toString().padStart(2, '0')}${date.getDate().toString().padStart(2, '0')}`;
+}
+
+function dateToMMDDYYYY(date: Date): string {
+  return `${(date.getMonth() + 1).toString().padStart(2, '0')}${date.getDate().toString().padStart(2, '0')}${date.getFullYear()}`;
+}
+
+function dateToDDMMYYYY(date: Date): string {
+  return `${date.getDate().toString().padStart(2, '0')}${(date.getMonth() + 1).toString().padStart(2, '0')}${date.getFullYear()}`;
+}
+
+function getAlternativeDsp(
+  domain: string,
+  selector: string,
+  oldDate: string,
+  newDate: string
+): DomainAndSelector {
+  const newSelector = selector.replace(oldDate, newDate);
+  // Some domains embed the date in the hostname too
+  // (e.g. selector=20230601, domain=zkhack-dev.20230601.gappssmtp.com).
+  // Replace in both so the guessed DSP is reachable.
+  const newDomain = domain.replace(oldDate, newDate);
+  return { domain: newDomain, selector: newSelector };
+}
+
+function findYYYYMMDD(
+  domain: string,
+  selector: string,
+  yearPattern: string,
+  alternatives: DomainAndSelector[],
+  newDate: Date
+) {
+  const re = new RegExp(`${yearPattern}(\\d{2})(\\d{2})`);
+  const match = selector.match(re);
+  if (match && match.index !== undefined) {
+    const oldDateStr = match[0];
+    const [year, month, day] = match.slice(1).map((s) => Number.parseInt(s));
+    if (!isValidDate(year, month, day)) {
+      return;
+    }
+    const newDateStr = dateToYYYYMMDD(newDate);
+    alternatives.push(
+      getAlternativeDsp(domain, selector, oldDateStr, newDateStr)
+    );
+  }
+}
+
+function findAABBYYYY(
+  domain: string,
+  selector: string,
+  yearPattern: string,
+  alternatives: DomainAndSelector[],
+  newDate: Date
+) {
+  const re = new RegExp(`(\\d{2})(\\d{2})${yearPattern}`);
+  const match = selector.match(re);
+  if (match && match.index !== undefined) {
+    const oldDateStr = match[0];
+    const [aa, bb, year] = match.slice(1).map((s) => Number.parseInt(s));
+    if (isValidDate(year, aa, bb)) {
+      const newDateStr = dateToMMDDYYYY(newDate);
+      alternatives.push(
+        getAlternativeDsp(domain, selector, oldDateStr, newDateStr)
+      );
+    }
+    if (isValidDate(year, bb, aa)) {
+      const newDateStr = dateToDDMMYYYY(newDate);
+      alternatives.push(
+        getAlternativeDsp(domain, selector, oldDateStr, newDateStr)
+      );
+    }
+  }
+}
+
+export function findAlternatives(
+  domain: string,
+  selector: string,
+  newDate: Date
+): DomainAndSelector[] {
+  const alternatives: DomainAndSelector[] = [];
+  const y0 = newDate.getFullYear().toString();
+  const y1 = (newDate.getFullYear() - 1).toString();
+  const y2 = (newDate.getFullYear() - 2).toString();
+  const yearPattern = `(${y0}|${y1}|${y2})`;
+  findYYYYMMDD(domain, selector, yearPattern, alternatives, newDate);
+  findAABBYYYY(domain, selector, yearPattern, alternatives, newDate);
+  return alternatives;
+}
+
+export async function guessSelectors(
+  domain: string,
+  selector: string,
+  newDate: Date
+): Promise<DomainAndSelector[]> {
+  const alternatives = findAlternatives(domain, selector, newDate);
+  const addedAlternatives: DomainAndSelector[] = [];
+  for (const altDsp of alternatives) {
+    try {
+      const result = await addDomainSelectorPair(
+        altDsp.domain,
+        altDsp.selector,
+        'selector_guesser'
+      );
+      if (result.added) {
+        logger.info('selector_guesser_added', altDsp);
+        addedAlternatives.push(altDsp);
+      }
+    } catch (error) {
+      logger.warn('selector_guesser_failed', {
+        ...altDsp,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return addedAlternatives;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -49,6 +49,15 @@ export function decodeMimeEncodedText(encodedText: string) {
   return encodedText; // Return the original text if unhandled encoding
 }
 
+export function isValidDate(year: number, month: number, day: number) {
+  const date = new Date(year, month - 1, day);
+  return (
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day
+  );
+}
+
 export const formatDate = (timestamp: string) => {
   try {
     let date: Date;


### PR DESCRIPTION
## Summary

The 2026-06-04 cutover repointed `archive.prove.email` at `archive-new`, but the new archive was missing `/api/batch_update`. The legacy DKIM-record refresh runs out of a GCE cron polling that endpoint every minute, so since the cutover DKIM records in `archive_new` have stopped refreshing from DNS.

Port the route and its selector-guesser helper from `zkemail/archive.zk.email` so the existing cron resumes succeeding the moment this deploys, with no cron-side change needed (the cron points at `https://archive.prove.email/api/batch_update`, which already routes to `archive-new`).

## Changes

- **`src/app/api/batch_update/route.ts`** (new): `Bearer CRON_SECRET` auth, finds `DomainSelectorPair`s with `lastRecordUpdate <= now() - 1 day`, re-fetches DNS via `fetchAndStoreDkimDnsRecord`, bumps the DSP timestamp, runs `guessSelectors` to discover date-rotated selectors. Same response shape as legacy (`{updatedRecords, addedAlternatives}`). Adds `batch_size` validation that legacy lacked (must be positive integer ≤ 1000).
- **`src/lib/selectorGuesser.ts`** (new): date-pattern selector guesser ported from legacy `src/lib/selector_guesser.ts`. Imports adapted to this repo's `utilsServer` naming. Uses the project `logger` instead of `console.log`, and wraps per-alternative failures so one bad guess doesn't abort the batch.
- **`src/lib/utils.ts`**: add `isValidDate` helper used by `selectorGuesser`.

## Why this was missed during the original audit (REG-705)

I checked `zkemail/archive.zk.email:src/util/cron.ts` and concluded the legacy worker only did JWKS refresh, so the new archive's existing `archive-jwks-cron` was full parity. The DKIM-record refresh is actually a separate mechanism: an HTTP endpoint polled by a Linux crontab on an external GCE VM, not the Render background worker. Out of audit scope at the time. Surfaced from Render logs showing 340+ 404s/day on `/api/batch_update`.

## Test plan

- [x] Local: `pnpm prisma generate && pnpm exec tsc --noEmit` clean
- [x] Local: `pnpm lint:check` clean for new files
- [x] After merge + deploy: Render logs show 200s (not 404s) for GET `/api/batch_update?batch_size=10` from the cron VM (first 200 at 2026-06-04 18:13:27 UTC, ~9 min after deploy went live)
- [x] After deploy: query `SELECT max("lastRecordUpdate") FROM "DomainSelectorPair"` on `archive_new` advanced from 16:08:29 → 18:14:49 (was frozen since cutover until cron started succeeding)
- [x] After deploy: `DkimRecord.lastSeenAt` advanced from 16:08:29 → 18:14:02. 19 DkimRecords + 17 DSPs updated in the first ~5 min after cron started landing
- [x] `guessSelectors` is being invoked per DSP in the batch loop (code path verified live). Count of `sourceIdentifier='selector_guesser'` DSPs unchanged at 207 in the first verification window — expected, since most DSPs in `archive_new` don't have year-pattern selectors and existing year-pattern DSPs already had their alternatives discovered during legacy operation. Will accrue gradually as the cron processes stale DSPs

## Out of scope

- Anything that touches the cron on the VM side. The cron continues running unmodified.
- Migrating `call_batch_update.py` itself out of the legacy repo.

## Related

- REG-717 (this work)
- REG-705 (data cutover, surfaced this gap)
- REG-703 (legacy decommission, blocked on knowing what else might still be needed like this)
- REG-699 (parent: archive infra cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)