### PR TITLE
fix: /api/stats POST fails closed when CRON_SECRET is unset (REG-719)

### DIFF
--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -13,7 +13,7 @@ export async function POST(request: Request) {
   const authHeader = request.headers.get('authorization');
   const cronSecret = process.env.CRON_SECRET;
 
-  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 
+import { serverError } from '@/lib/api-response';
 import { getArchiveStats, refreshArchiveStats } from '@/lib/db';
+import { logger } from '@/lib/logger';
 
 // GET - read cached stats (instant)
 export async function GET() {
@@ -17,6 +19,13 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const stats = await refreshArchiveStats();
-  return NextResponse.json(stats);
+  try {
+    const stats = await refreshArchiveStats();
+    return NextResponse.json(stats);
+  } catch (error) {
+    logger.error('stats_refresh_failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return serverError();
+  }
 }


### PR DESCRIPTION
## Summary

`src/app/api/stats/route.ts:16` previously had:

```ts
if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
}
```

The `cronSecret && ...` short-circuit means: when `process.env.CRON_SECRET` is missing or empty, the auth check is skipped entirely and any POST executes `refreshArchiveStats()` — a heavy `pg_class.reltuples` scan plus a write to `StatsCache`. Currently fine in production because the env var is set, but the latent bug is that secret rotation, copy-paste of env vars to a new service, or a misconfigured deploy silently opens the endpoint.

Swap to the same pattern `/api/batch_update` uses (the one we just ported in REG-717):

```ts
if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
}
```

Now: missing env var → 401, mismatched header → 401. Fail closed.

A second commit (02c2793) wraps `refreshArchiveStats()` in try/catch + returns `serverError()` on failure, matching the typed-JSON envelope used elsewhere (per CodeRabbit nitpick).

## Test plan

- [x] Local: `pnpm prisma generate && pnpm exec tsc --noEmit` clean (pre-commit + CI green)
- [x] With `CRON_SECRET` set + valid bearer header → POST returns 200 (unchanged) — code-verified, same auth comparison
- [x] With `CRON_SECRET` set + missing/wrong header → POST returns 401 (unchanged) — code-verified
- [x] With `CRON_SECRET` unset → POST returns 401 (NEW: was executing the refresh) — code-verified by the condition change

## Out of scope

- Adding rate limiting on the auth check (the bearer secret is the gate; brute force is infeasible for a real secret)
- Adding constant-time secret compare via `crypto.timingSafeEqual` — `/api/batch_update` and `/api/stats` would both benefit, separate hardening PR
- Reconciling/removing the orphaned GCP Cloud Scheduler config (CodeRabbit's "Major" finding) — tracked in REG-721 / PR #36 as a terraform-removal PR rather than reconciling dead config

## Related

- REG-719 (this)
- REG-721 (follow-up: drop the orphaned terraform)
- REG-717 (where the correct pattern came from)
- REG-718 (parity audit that surfaced this)
- REG-699 (parent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)