### PR TITLE
perf: shrink pg pool and LRU caches to relieve RSS pressure (REG-722)

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -14,7 +14,7 @@ import { DnsDkimFetchResult, fetchJsonWebKeySet, fetchx509Cert } from './utils';
 
 // In process Cache configuration (LRU cache)
 const CACHE_TTL = 30 * 60 * 1000; // 30 minutes
-const CACHE_MAX_SIZE = 1000; // Maximum 1000 entries
+const CACHE_MAX_SIZE = 200;
 
 // Create LRU cache instances
 const domainCache = new LRUCache<string, RecordWithSelector[]>({
@@ -51,7 +51,7 @@ const createPrismaClient = () => {
   // Create a pg Pool with optimized connection settings
   const pool = new Pool({
     connectionString: process.env.DATABASE_URL,
-    max: 20, // Max connections
+    max: 5,
     idleTimeoutMillis: 30000, // 30 seconds idle timeout
     connectionTimeoutMillis: 10000, // 10 seconds connection timeout
     // Render's NAT closes idle sockets aggressively. Without keepAlive


### PR DESCRIPTION
## Summary

- Drop pg `Pool` `max` from **20 → 5** so we stop holding ~3-5 MB of libpq buffer + TLS state per idle slot on the 0.5 CPU container that can only run 2-3 concurrent queries anyway.
- Drop `CACHE_MAX_SIZE` from **1000 → 200** on the three shared LRU caches (`domainCache`, `domainSelectorCache`, `dspIdCache`); each entry holds full `RecordWithSelector[]` arrays with base64 `keyData`, and there's no byte cap. `statsCache` (max=1) is unaffected.

Both knobs lived in `src/lib/db.ts`. Two-line diff.

## Why

Since the 2026-06-04 cutover archive-new RSS has sat at 85-100% of the 512 MB ceiling and the service has crashed four times in three days (two oomKilled, two V8 `FATAL ERROR: Ineffective mark-compacts near heap limit` exit 134). V8 heap was only ~252 MB at crash time per the GC logs, so the binding constraint is **native memory** (libpq, Prisma adapter, socket buffers), not V8 heap. Bumping `--max-old-space-size` would make it worse.

Expected reclaim: ~75 MB from the pool, ~10-20 MB from the caches.

Full root-cause writeup in REG-722.

## Test plan

- [x] CI green
- [x] Merge to main; auto-deploy lands on archive-new
- [ ] Watch Render Application Metrics → Memory for 24 h
  - target: RSS stays under 80%
  - target: no new `server_failed` events (oomKilled or exit 134)
- [ ] If RSS still ≥ 85% after 24 h, open a follow-up to upgrade plan from Starter to Standard

### Post-deploy observation (open)

New instance `gfsqq` cold start at 08:34 UTC was 427 MB (83.3%), reached 469 MB (91.5%) by 09:21 UTC — basically the same steady state as the old instance (471 MB / 92%). Real reclaim looks like ~5-10 MB, not the ~85 MB estimated. The cheap fix did not move the needle meaningfully; the upgrade-plan follow-up will likely fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)