### PR TITLE
fix: stop labeling DNS-sourced keys as "Reverse Engineering"

### DIFF
--- a/src/app/search/SelectorDetails.tsx
+++ b/src/app/search/SelectorDetails.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
 import { analytics } from '@/lib/analytics';
-import { formatDate } from '@/lib/utils';
+import { dspSourceIdentifierToHumanReadable, formatDate } from '@/lib/utils';
 
 import { Badge } from '../../components/ui/badge';
 import ActivityChart from './ActivityChart';
@@ -215,24 +215,26 @@ const SelectorDetails = ({ data }: SelectorDetailsProps) => {
                           variant='source'
                           className='text-xs text-secondary sm:text-sm'
                         >
-                          {item.origin === 'Inbox Upload' ? (
-                            <>
-                              <EnvelopeSimpleIcon className='h-3 w-3 sm:h-4 sm:w-4' />
-                              <span className='text-xs leading-none font-normal tracking-tight'>
-                                Inbox Upload
-                              </span>
-                            </>
+                          {/* REASON: source must be derived from the actual
+                              origin identifier, not a binary "is it the literal
+                              string 'Inbox Upload'" check. item.origin carries
+                              raw identifiers (top_1m_lookup, scraper, api,
+                              public_key_gcd_batch, ...), so the old `=== 'Inbox
+                              Upload'` test never matched and EVERYTHING fell
+                              through to "Reverse Engineering" — mislabeling all
+                              the DNS-scraped keys. Use the shared mapping helper
+                              so DNS lookups show "Scraped", uploads show "Inbox
+                              upload", GCD-recovered keys show "Mail archive", etc. */}
+                          {item.origin === 'api' ||
+                          item.origin === 'api_auto' ||
+                          item.origin === 'public_key_gcd_cloud_function' ? (
+                            <EnvelopeSimpleIcon className='h-3 w-3 sm:h-4 sm:w-4' />
                           ) : (
-                            <>
-                              <ArrowsCounterClockwiseIcon className='h-3 w-3 text-secondary sm:h-4 sm:w-4' />
-                              <span className='text-xs leading-none font-normal tracking-tight sm:hidden'>
-                                Rev Eng
-                              </span>
-                              <span className='hidden text-xs leading-none font-normal tracking-tight sm:inline'>
-                                Reverse Engineering
-                              </span>
-                            </>
+                            <ArrowsCounterClockwiseIcon className='h-3 w-3 text-secondary sm:h-4 sm:w-4' />
                           )}
+                          <span className='text-xs leading-none font-normal tracking-tight'>
+                            {dspSourceIdentifierToHumanReadable(item.origin)}
+                          </span>
                         </Badge>
                         <FlagIcon
                           weight='fill'
@@ -276,7 +278,9 @@ const SelectorDetails = ({ data }: SelectorDetailsProps) => {
                       <DetailRow label='Last seen'>
                         {formatDate(item.lastActive)}
                       </DetailRow>
-                      <DetailRow label='Origin'>{item.origin}</DetailRow>
+                      <DetailRow label='Origin'>
+                        {dspSourceIdentifierToHumanReadable(item.origin)}
+                      </DetailRow>
 
                       <DetailRow label='Value'>
                         <div className='font-mono text-xs leading-relaxed break-all'>


### PR DESCRIPTION
## Problem

Every key in the archive UI shows the source badge **"Reverse Engineering"**, even though the large majority are fetched from **live DNS lookups**.

## Root cause

`src/app/search/SelectorDetails.tsx` derived the badge with a binary check:

```tsx
{item.origin === 'Inbox Upload' ? ( …Inbox Upload… ) : ( …Reverse Engineering… )}
```

But `item.origin` is the **raw source identifier** (`actions.ts`: `record.source ?? domainSelectorPair.sourceIdentifier ?? 'Unknown'`), i.e. values like `top_1m_lookup`, `scraper`, `api`, `api_auto`, `public_key_gcd_batch`, `selector_guesser`, `try_selectors`, `seed`. It is **never** the literal string `'Inbox Upload'`, so the condition never matched and **everything** fell through to the "Reverse Engineering" branch.

Additionally, the DNS-fetch path (`createDkimRecord`) never sets `source`, so DNS keys fall back to the DSP's `sourceIdentifier` (e.g. `top_1m_lookup`) — which the old code also mislabeled.

## Fix

Use the existing `dspSourceIdentifierToHumanReadable()` mapping for both the badge and the Origin detail row, so each key shows its true provenance:

| origin | label |
|---|---|
| `top_1m_lookup`, `scraper` | Scraped (DNS) |
| `api`, `api_auto` | Inbox upload |
| `public_key_gcd_batch` | Mail archive |
| `public_key_gcd_cloud_function` | Inbox upload |
| `selector_guesser` | Selector guesser |
| `try_selectors` | Try selectors |
| `seed` | Seed |
| `unknown` | Unknown |

Icon: envelope for upload-type sources, counter-clockwise arrows otherwise.

## Notes / follow-ups for the team
- `dspSourceIdentifierToHumanReadable` maps `public_key_gcd_batch` → "Mail archive" while the separate `keySourceIdentifierToHumanReadable` maps the same id → "Reverse engineered". If you want GCD-recovered keys to read literally "Reverse engineered" in this badge, that's a one-line follow-up — flagging the inconsistency rather than deciding it here.
- If "Scraped" should read "DNS lookup" for clarity, rename it in the helper (single source of truth, used by other call sites too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Origin and source information now displays in human-readable format instead of technical identifiers for improved clarity.
  * Source types now display with appropriate visual indicators for better identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->