### PR TITLE
fix(stats): use exact COUNT(DISTINCT) instead of inaccurate pg_stats estimates

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prettier:check": "prettier --check .",
     "start": "next start",
     "jwks:update": "tsx scripts/update-jwks.ts",
+    "stats:refresh": "tsx scripts/refresh-stats.ts",
     "backfill:domain-unicode": "tsx scripts/backfill-domain-unicode.ts"
   },
   "dependencies": {

--- a/scripts/refresh-stats.ts
+++ b/scripts/refresh-stats.ts
@@ -1,0 +1,63 @@
+// Standalone archive-stats refresh script. Intended to be run on a Render
+// Cron Job, the same way scripts/update-jwks.ts is.
+//
+// What it does:
+//   1. Runs refreshArchiveStats() (exact COUNT(DISTINCT) over
+//      DomainSelectorPair + COUNT(*) of DkimRecord).
+//   2. Upserts the result into the StatsCache table (id=1), which the
+//      landing page / /api/stats GET reads.
+//
+// Why this exists: the homepage stats are served from the StatsCache
+// snapshot and are ONLY updated when something triggers a refresh. Without
+// this cron the numbers freeze at whatever last wrote them. (They were
+// stuck at 0 because nothing ever ran the refresh.)
+//
+// Usage:
+//   pnpm stats:refresh         uses DATABASE_URL from .env
+//
+// Render Cron Job setup (mirrors archive-new-jwks-cron):
+//   - Service type: Cron Job
+//   - Repo: zkemail/archive
+//   - Branch: main
+//   - Schedule: hourly ("0 * * * *")
+//   - Build command: pnpm install --frozen-lockfile && pnpm prisma generate
+//   - Run command:   pnpm stats:refresh
+//   - Env vars:      DATABASE_URL (same value as the archive-new web service)
+
+import 'dotenv/config';
+
+import { refreshArchiveStats } from '../src/lib/db';
+
+async function main() {
+  console.log(`[${new Date().toISOString()}] starting archive stats refresh`);
+
+  const stats = await refreshArchiveStats();
+
+  // refreshArchiveStats always returns the computed values (it throws on a
+  // query error, which is caught below and fails the run). A sanity guard:
+  // an all-zero result on a populated archive almost certainly means the
+  // query hit the wrong DB / empty tables, so fail loudly rather than
+  // silently caching zeros.
+  if (
+    stats.domainSelectorPairs === 0 &&
+    stats.dkimKeys === 0 &&
+    stats.uniqueDomains === 0
+  ) {
+    console.error(
+      'Stats refresh produced all zeros — refusing to treat as success. Check DATABASE_URL / tables.'
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `[${new Date().toISOString()}] stats refresh OK: ` +
+      `domains=${stats.uniqueDomains} selectors=${stats.uniqueSelectors} ` +
+      `dsp=${stats.domainSelectorPairs} keys=${stats.dkimKeys}`
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('stats refresh threw:', err);
+  process.exit(1);
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -400,7 +400,14 @@ export async function getArchiveStats(): Promise<ArchiveStats> {
 
 // Heavy computation - call via cron/API, not on page load
 export async function refreshArchiveStats(): Promise<ArchiveStats> {
-  // Use pg_class reltuples for fast approximate counts (updated by ANALYZE/VACUUM)
+  // REASON: We previously read pg_stats.n_distinct / pg_class.reltuples for
+  // "fast approximate" counts. Those are sampled planner statistics (ANALYZE
+  // looks at ~30k rows) and are wildly inaccurate for distinct counts on a
+  // large table — production showed unique_selectors=728 (real: 5,932) and
+  // unique_domains=220,967 (real: 409,747). reltuples happened to be close for
+  // raw row counts but n_distinct was not. Since this runs on a cron (not page
+  // load), do exact COUNT(DISTINCT). The two distinct aggregates over
+  // DomainSelectorPair are computed in a single scan via a CTE.
   const result = await prisma.$queryRaw<
     [
       {
@@ -411,21 +418,19 @@ export async function refreshArchiveStats(): Promise<ArchiveStats> {
       },
     ]
   >`
+    WITH dsp AS (
+      SELECT
+        COUNT(DISTINCT domain)   AS unique_domains,
+        COUNT(DISTINCT selector) AS unique_selectors,
+        COUNT(*)                 AS dsp_count
+      FROM "DomainSelectorPair"
+    )
     SELECT
-      (SELECT CASE
-        WHEN n_distinct < 0 THEN (reltuples * ABS(n_distinct))::int
-        ELSE n_distinct::int
-       END
-       FROM pg_stats ps JOIN pg_class pc ON ps.tablename = pc.relname
-       WHERE ps.tablename = 'DomainSelectorPair' AND ps.attname = 'domain') as unique_domains,
-      (SELECT CASE
-        WHEN n_distinct < 0 THEN (reltuples * ABS(n_distinct))::int
-        ELSE n_distinct::int
-       END
-       FROM pg_stats ps JOIN pg_class pc ON ps.tablename = pc.relname
-       WHERE ps.tablename = 'DomainSelectorPair' AND ps.attname = 'selector') as unique_selectors,
-      (SELECT reltuples::int FROM pg_class WHERE relname = 'DomainSelectorPair') as dsp_count,
-      (SELECT reltuples::int FROM pg_class WHERE relname = 'DkimRecord') as dkim_count
+      dsp.unique_domains,
+      dsp.unique_selectors,
+      dsp.dsp_count,
+      (SELECT COUNT(*) FROM "DkimRecord") AS dkim_count
+    FROM dsp
   `;
 
   const stats: ArchiveStats = {


### PR DESCRIPTION
## Problem

The archive landing-page stats were significantly undercounted. `refreshArchiveStats()` derived unique-domain and unique-selector counts from **`pg_stats.n_distinct`** (and `pg_class.reltuples`), which are *sampled planner estimates* (ANALYZE samples ~30k rows). For distinct counts on a large table these are wildly off.

### Observed in production (verified with real `COUNT(DISTINCT)`)

| metric | pg_stats estimate (shown) | real count |
|---|---|---|
| unique selectors | **728** | **5,932** (~8× undercount) |
| unique domains | **220,967** | **409,747** (~1.85× undercount) |
| domain-selector pairs | 1,022,055 | 1,022,055 ✓ |
| dkim keys | 1,480,204 | 1,479,850 ✓ (reltuples ~fine for raw rows) |

`reltuples` was acceptable for raw row counts, but `n_distinct` was not usable for the distinct metrics.

## Fix

`refreshArchiveStats()` is explicitly documented as "Heavy computation - call via cron/API, not on page load", so exactness is affordable there. Switch to exact `COUNT(DISTINCT …)`. Both distinct aggregates over `DomainSelectorPair` are computed in a **single scan** via a CTE; `DkimRecord` is a separate `COUNT(*)`.

```sql
WITH dsp AS (
  SELECT COUNT(DISTINCT domain)   AS unique_domains,
         COUNT(DISTINCT selector) AS unique_selectors,
         COUNT(*)                 AS dsp_count
  FROM "DomainSelectorPair"
)
SELECT dsp.unique_domains, dsp.unique_selectors, dsp.dsp_count,
       (SELECT COUNT(*) FROM "DkimRecord") AS dkim_count
FROM dsp
```

## Already remediated live

The production `StatsCache` row has been corrected out-of-band to the real values (409,747 / 5,932 / 1,022,055 / 1,479,850), so the site shows accurate numbers now (within the 10-min LRU TTL). This PR ensures the **next** `refreshArchiveStats()` run doesn't revert them to the estimates.

> Note: there is currently no cron calling `POST /api/stats`, so stats only update when triggered manually. Wiring a periodic refresh (mirroring `archive-new-jwks-cron`) is a recommended follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)